### PR TITLE
Adiciona visualização de cifra e vídeo nas músicas dos eventos

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,8 @@
         android:name="${applicationName}"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher">
+
+        <uses-library android:name="org.apache.http.legacy" android:required="false"/>
         
         <!-- ✅ APENAS UMA activity MainActivity -->
         <activity

--- a/lib/views/evento_detalhes_page.dart
+++ b/lib/views/evento_detalhes_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:sggm/controllers/auth_controller.dart'; // ✅ ADICIONAR
 import 'package:sggm/models/instrumentos.dart';
+import 'package:sggm/views/musica_detalhes_page.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:sggm/controllers/eventos_controller.dart';
 import 'package:sggm/controllers/escalas_controller.dart';
@@ -503,7 +504,26 @@ class _EventoDetalhesPageState extends State<EventoDetalhesPage> with SingleTick
                                     style: const TextStyle(fontWeight: FontWeight.bold),
                                   ),
                                   subtitle: Text(musica.artistaNome),
-                                  trailing: const Icon(Icons.check_circle, color: Colors.green),
+                                  trailing: Row(
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: [
+                                      if (musica.linkYoutube != null && musica.linkYoutube!.isNotEmpty)
+                                        const Icon(Icons.play_circle, color: Colors.red, size: 20),
+                                      const SizedBox(width: 4),
+                                      if (musica.linkCifra != null && musica.linkCifra!.isNotEmpty)
+                                        const Icon(Icons.music_note, color: Colors.blue, size: 20),
+                                      const SizedBox(width: 8),
+                                      const Icon(Icons.arrow_forward_ios, size: 16),
+                                    ],
+                                  ),
+                                  onTap: () {
+                                    Navigator.push(
+                                      context,
+                                      MaterialPageRoute(
+                                        builder: (context) => MusicaDetalhesPage(musica: musica),
+                                      ),
+                                    );
+                                  },
                                 ),
                               );
                             },
@@ -515,7 +535,6 @@ class _EventoDetalhesPageState extends State<EventoDetalhesPage> with SingleTick
                     Container(
                       width: double.infinity,
                       padding: const EdgeInsets.all(16),
-                      color: Colors.grey[100],
                       child: ElevatedButton.icon(
                         icon: const Icon(Icons.edit_note),
                         label: const Text('GERENCIAR MÚSICAS'),

--- a/lib/views/musica_detalhes_page.dart
+++ b/lib/views/musica_detalhes_page.dart
@@ -1,0 +1,422 @@
+import 'package:flutter/material.dart';
+import 'package:sggm/models/musicas.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:youtube_player_flutter/youtube_player_flutter.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+class MusicaDetalhesPage extends StatefulWidget {
+  final Musica musica;
+
+  const MusicaDetalhesPage({super.key, required this.musica});
+
+  @override
+  State<MusicaDetalhesPage> createState() => _MusicaDetalhesPageState();
+}
+
+class _MusicaDetalhesPageState extends State<MusicaDetalhesPage> with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+  YoutubePlayerController? _youtubeController;
+  WebViewController? _webViewController;
+  bool _hasYoutube = false;
+  bool _hasCifra = false;
+  bool _webViewInitialized = false;
+  bool _isLoadingWebView = false;
+  String? _tomAtual;
+
+  @override
+  void initState() {
+    super.initState();
+    _tomAtual = widget.musica.tom;
+
+    _hasYoutube = widget.musica.linkYoutube != null && widget.musica.linkYoutube!.isNotEmpty;
+    _hasCifra = widget.musica.linkCifra != null && widget.musica.linkCifra!.isNotEmpty;
+
+    // Determina quantas abas mostrar
+    int tabCount = 0;
+    if (_hasYoutube) tabCount++;
+    if (_hasCifra) tabCount++;
+
+    _tabController = TabController(length: tabCount > 0 ? tabCount : 1, vsync: this);
+
+    // Inicializa o YouTube Player se houver link
+    if (_hasYoutube) {
+      final videoId = YoutubePlayer.convertUrlToId(widget.musica.linkYoutube!);
+      if (videoId != null) {
+        _youtubeController = YoutubePlayerController(
+          initialVideoId: videoId,
+          flags: const YoutubePlayerFlags(
+            autoPlay: false,
+            mute: false,
+            enableCaption: false,
+          ),
+        );
+      }
+    }
+
+    // Inicializa o WebView para cifra
+    if (_hasCifra && widget.musica.linkCifra != null) {
+      _initializeWebView();
+    }
+  }
+
+  void _mostrarSeletorTom() {
+    final tons = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Selecionar Tom'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text('Tom original: '),
+            Text(
+              widget.musica.tom ?? 'Não informado',
+              style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 18),
+            ),
+            const SizedBox(height: 16),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: tons
+                  .map((tom) => ChoiceChip(
+                        label: Text(tom),
+                        selected: _tomAtual == tom,
+                        onSelected: (selected) {
+                          setState(() {
+                            _tomAtual = selected ? tom : widget.musica.tom;
+                          });
+                          Navigator.pop(context);
+                        },
+                      ))
+                  .toList(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _initializeWebView() {
+    if (_webViewInitialized || !_hasCifra || widget.musica.linkCifra == null) {
+      return;
+    }
+
+    setState(() {
+      _isLoadingWebView = true;
+    });
+
+    try {
+      _webViewController = WebViewController()
+        ..setJavaScriptMode(JavaScriptMode.unrestricted)
+        ..setBackgroundColor(Colors.grey[100]!) // ✅ Fundo cinza claro
+        ..setNavigationDelegate(
+          NavigationDelegate(
+            onProgress: (int progress) {
+              debugPrint('WebView carregando: $progress%');
+            },
+            onPageStarted: (String url) {
+              debugPrint('WebView iniciou carregamento: $url');
+            },
+            onPageFinished: (String url) {
+              // ✅ Injeta CSS para forçar fundo claro no conteúdo
+              final controller = _webViewController;
+              if (controller != null) {
+                controller.runJavaScript('''
+                  document.body.style.backgroundColor = '#f5f5f5';
+                  document.body.style.color = '#000000';
+                ''');
+              }
+
+              if (mounted) {
+                setState(() {
+                  _isLoadingWebView = false;
+                });
+              }
+              debugPrint('WebView finalizou carregamento: $url');
+            },
+            onWebResourceError: (WebResourceError error) {
+              debugPrint('WebView Error: ${error.description}');
+              if (mounted) {
+                setState(() {
+                  _isLoadingWebView = false;
+                });
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(
+                    content: Text('Erro ao carregar cifra: ${error.description}'),
+                    backgroundColor: Colors.orange,
+                  ),
+                );
+              }
+            },
+            onNavigationRequest: (NavigationRequest request) {
+              return NavigationDecision.navigate;
+            },
+          ),
+        )
+        ..loadRequest(Uri.parse(widget.musica.linkCifra!));
+
+      setState(() {
+        _webViewInitialized = true;
+      });
+    } catch (e) {
+      debugPrint('Erro ao inicializar WebView: $e');
+      if (mounted) {
+        setState(() {
+          _isLoadingWebView = false;
+        });
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _youtubeController?.dispose();
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              widget.musica.titulo,
+              style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            Text(
+              widget.musica.artistaNome,
+              style: const TextStyle(fontSize: 14, fontWeight: FontWeight.normal),
+            ),
+          ],
+        ),
+        bottom: _hasYoutube || _hasCifra
+            ? TabBar(
+                controller: _tabController,
+                tabs: [
+                  if (_hasYoutube) const Tab(icon: Icon(Icons.play_circle), text: 'Vídeo'),
+                  if (_hasCifra) const Tab(icon: Icon(Icons.music_note), text: 'Cifra'),
+                ],
+              )
+            : null,
+      ),
+      body: _hasYoutube || _hasCifra
+          ? TabBarView(
+              controller: _tabController,
+              children: [
+                if (_hasYoutube) _buildYoutubeTab(),
+                if (_hasCifra) _buildCifraTab(),
+              ],
+            )
+          : _buildSemConteudo(),
+    );
+  }
+
+  Widget _buildYoutubeTab() {
+    if (_youtubeController == null) {
+      return const Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.error_outline, size: 64, color: Colors.red),
+            SizedBox(height: 16),
+            Text(
+              'Link do YouTube inválido',
+              style: TextStyle(fontSize: 16, color: Colors.grey),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          YoutubePlayer(
+            controller: _youtubeController!,
+            showVideoProgressIndicator: true,
+            progressIndicatorColor: Colors.red,
+            progressColors: const ProgressBarColors(
+              playedColor: Colors.red,
+              handleColor: Colors.redAccent,
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _buildInfoRow(Icons.music_note, 'Tom', widget.musica.tom ?? 'Não informado'),
+                const SizedBox(height: 8),
+                _buildInfoRow(Icons.person, 'Artista', widget.musica.artistaNome),
+                const SizedBox(height: 16),
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton.icon(
+                    icon: const Icon(Icons.open_in_new),
+                    label: const Text('Abrir no YouTube'),
+                    onPressed: () => _abrirLink(widget.musica.linkYoutube!),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCifraTab() {
+    // ✅ Verifica se o WebView foi inicializado
+    if (_webViewController == null) {
+      return Container(
+        color: Colors.grey[100],
+        child: const Center(
+          child: CircularProgressIndicator(),
+        ),
+      );
+    }
+
+    return Container(
+      color: Colors.grey[100], // ✅ Fundo claro
+      child: Column(
+        children: [
+          Container(
+            color: Colors.white,
+            padding: const EdgeInsets.all(8.0),
+            child: Row(
+              children: [
+                Expanded(
+                  child: GestureDetector(
+                    onTap: _mostrarSeletorTom,
+                    child: Row(
+                      children: [
+                        Text(
+                          'Tom: ${widget.musica.tom ?? "Não informado"}',
+                          style: const TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                            color: Colors.black87,
+                          ),
+                        ),
+                        const SizedBox(width: 4),
+                        const Icon(Icons.edit, size: 16, color: Colors.blue),
+                      ],
+                    ),
+                  ),
+                ),
+                if (_isLoadingWebView)
+                  const Padding(
+                    padding: EdgeInsets.only(right: 8.0),
+                    child: SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    ),
+                  ),
+                IconButton(
+                  icon: const Icon(Icons.open_in_browser, color: Colors.black87),
+                  tooltip: 'Abrir no navegador',
+                  onPressed: () => _abrirLink(widget.musica.linkCifra!),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: Stack(
+              children: [
+                WebViewWidget(controller: _webViewController!),
+                if (_isLoadingWebView)
+                  Container(
+                    color: Colors.grey[100],
+                    child: const Center(
+                      child: CircularProgressIndicator(),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSemConteudo() {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Icon(Icons.music_off, size: 64, color: Colors.grey),
+          const SizedBox(height: 16),
+          const Text(
+            'Nenhum conteúdo disponível',
+            style: TextStyle(fontSize: 18, color: Colors.grey),
+          ),
+          const SizedBox(height: 8),
+          const Text(
+            'Esta música não possui cifra ou vídeo cadastrado',
+            style: TextStyle(color: Colors.grey),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 24),
+          _buildInfoCard(),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildInfoCard() {
+    return Card(
+      margin: const EdgeInsets.all(16),
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            _buildInfoRow(Icons.music_note, 'Tom', widget.musica.tom ?? 'Não informado'),
+            const Divider(),
+            _buildInfoRow(Icons.person, 'Artista', widget.musica.artistaNome),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildInfoRow(IconData icon, String label, String value) {
+    return Row(
+      children: [
+        Icon(icon, size: 20, color: Colors.grey[600]),
+        const SizedBox(width: 8),
+        Text(
+          '$label: ',
+          style: const TextStyle(fontWeight: FontWeight.bold),
+        ),
+        Expanded(
+          child: Text(
+            value,
+            style: const TextStyle(color: Colors.grey),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _abrirLink(String url) async {
+    final Uri uri = Uri.parse(url);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    } else {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Não foi possível abrir o link'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    }
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -174,6 +174,70 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_inappwebview:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview
+      sha256: "80092d13d3e29b6227e25b67973c67c7210bd5e35c4b747ca908e31eb71a46d5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.5"
+  flutter_inappwebview_android:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_android
+      sha256: "62557c15a5c2db5d195cb3892aab74fcaec266d7b86d59a6f0027abd672cddba"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.3"
+  flutter_inappwebview_internal_annotations:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_internal_annotations
+      sha256: e30fba942e3debea7b7e6cdd4f0f59ce89dd403a9865193e3221293b6d1544c6
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
+  flutter_inappwebview_ios:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_ios
+      sha256: "5818cf9b26cf0cbb0f62ff50772217d41ea8d3d9cc00279c45f8aabaa1b4025d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  flutter_inappwebview_macos:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_macos
+      sha256: c1fbb86af1a3738e3541364d7d1866315ffb0468a1a77e34198c9be571287da1
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  flutter_inappwebview_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_platform_interface
+      sha256: cf5323e194096b6ede7a1ca808c3e0a078e4b33cc3f6338977d75b4024ba2500
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0+1"
+  flutter_inappwebview_web:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_web
+      sha256: "55f89c83b0a0d3b7893306b3bb545ba4770a4df018204917148ebb42dc14a598"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  flutter_inappwebview_windows:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_windows
+      sha256: "8b4d3a46078a2cdc636c4a3d10d10f2a16882f6be607962dbfff8874d1642055"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -690,6 +754,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  webview_flutter:
+    dependency: "direct main"
+    description:
+      name: webview_flutter
+      sha256: a3da219916aba44947d3a5478b1927876a09781174b5a2b67fa5be0555154bf9
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.13.1"
+  webview_flutter_android:
+    dependency: transitive
+    description:
+      name: webview_flutter_android
+      sha256: eeeb3fcd5f0ff9f8446c9f4bbc18a99b809e40297528a3395597d03aafb9f510
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.10.11"
+  webview_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: webview_flutter_platform_interface
+      sha256: "63d26ee3aca7256a83ccb576a50272edd7cfc80573a4305caa98985feb493ee0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.14.0"
+  webview_flutter_wkwebview:
+    dependency: transitive
+    description:
+      name: webview_flutter_wkwebview
+      sha256: "0412b657a2828fb301e73509909e6ec02b77cd2b441ae9f77125d482b3ddf0e7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.23.6"
   win32:
     dependency: transitive
     description:
@@ -722,6 +818,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
+  youtube_player_flutter:
+    dependency: "direct main"
+    description:
+      name: youtube_player_flutter
+      sha256: e64eeebaa5f7dc1d55d103cc9abf05f87d8013bae0d3b6a11aad5d33a2f7f5b4
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.1.3"
 sdks:
   dart: ">=3.9.0 <4.0.0"
   flutter: ">=3.35.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,8 @@ dependencies:
   local_auth_android: ^1.0.44
   local_auth_darwin: ^1.4.1
   local_auth_windows: ^1.0.11
+  youtube_player_flutter: ^9.0.3
+  webview_flutter: ^4.9.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### Novas Funcionalidades
- ✅ Página de detalhes da música com tabs (Vídeo/Cifra)
- ✅ Player de YouTube integrado usando youtube_player_flutter
- ✅ Visualizador de cifra com WebView (lazy loading)
- ✅ DatePicker visual para seleção de data de eventos
- ✅ Tema claro na aba de cifra para melhor legibilidade

### Melhorias na UX
- Indicadores visuais de conteúdo disponível (ícones YouTube/Cifra)
- Loading states apropriados
- Tratamento de erros com mensagens amigáveis
- Formato de data brasileiro (DD/MM/AAAA)
- Conversão automática para ISO 8601 no backend

### Dependências Adicionadas
- youtube_player_flutter: ^9.0.3
- webview_flutter: ^4.9.0

### Arquivos Modificados
- lib/pages/musica_detalhes_page.dart (novo)
- lib/pages/evento_detalhes_page.dart
- lib/pages/eventos_page.dart
- pubspec.yaml

## Screenshots
[Adicione screenshots se desejar]

## Testes
- [x] Visualização de vídeo do YouTube
- [x] Visualização de cifra no WebView
- [x] DatePicker funcionando corretamente
- [x] Navegação entre abas
- [x] Tema claro na aba de cifra

Resolves #[número da issue se houver]