### PR TITLE
Adicionar confirmação antes de excluir registros

### DIFF
--- a/lib/views/escalas_page.dart
+++ b/lib/views/escalas_page.dart
@@ -7,6 +7,7 @@ import 'package:sggm/controllers/instrumentos_controller.dart';
 import 'package:sggm/controllers/musicos_controller.dart';
 import 'package:sggm/models/escalas.dart';
 import 'package:sggm/models/instrumentos.dart';
+import 'package:sggm/views/widgets/dialogs/confirm_delete_dialog.dart';
 import 'package:sggm/views/widgets/loading/shimmer_card.dart';
 
 class EscalasPage extends StatefulWidget {
@@ -418,48 +419,35 @@ class _EscalasPageState extends State<EscalasPage> {
     );
   }
 
-  void _confirmarDelecao(BuildContext context, Escala escala) {
-    showDialog(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Confirmar Exclusão'),
-        content: Text('Deseja remover ${escala.musicoNome ?? "este músico"} da escala?'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx),
-            child: const Text('Cancelar'),
-          ),
-          ElevatedButton(
-            onPressed: () async {
-              Navigator.pop(ctx);
-              if (escala.id == null) return;
-              try {
-                await context.read<EscalasProvider>().deletarEscala(escala.id!);
-                if (context.mounted) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: Text('Escala removida com sucesso'),
-                      backgroundColor: Colors.green,
-                    ),
-                  );
-                }
-              } catch (e) {
-                if (context.mounted) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: Text('Erro ao remover escala'),
-                      backgroundColor: Colors.red,
-                    ),
-                  );
-                }
-              }
-            },
-            style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
-            child: const Text('Excluir'),
-          ),
-        ],
-      ),
+  void _confirmarDelecao(BuildContext context, Escala escala) async {
+    final confirmed = await ConfirmDeleteDialog.show(
+      context,
+      entityName: escala.musicoNome ?? 'este músico',
+      message: 'Deseja remover ${escala.musicoNome ?? "este músico"} da escala?\nEsta ação não pode ser desfeita.',
     );
+
+    if (confirmed && context.mounted && escala.id != null) {
+      try {
+        await context.read<EscalasProvider>().deletarEscala(escala.id!);
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Escala removida com sucesso'),
+              backgroundColor: Colors.green,
+            ),
+          );
+        }
+      } catch (e) {
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Erro ao remover escala'),
+              backgroundColor: Colors.red,
+            ),
+          );
+        }
+      }
+    }
   }
 
   @override

--- a/lib/views/evento_detalhes_page.dart
+++ b/lib/views/evento_detalhes_page.dart
@@ -4,6 +4,7 @@ import 'package:sggm/controllers/auth_controller.dart'; // ✅ ADICIONAR
 import 'package:sggm/models/instrumentos.dart';
 import 'package:sggm/util/app_logger.dart';
 import 'package:sggm/views/musica_detalhes_page.dart';
+import 'package:sggm/views/widgets/dialogs/confirm_delete_dialog.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:sggm/controllers/eventos_controller.dart';
 import 'package:sggm/controllers/escalas_controller.dart';
@@ -594,8 +595,14 @@ class _EventoDetalhesPageState extends State<EventoDetalhesPage> with SingleTick
                                       ),
                                       IconButton(
                                         icon: const Icon(Icons.delete_outline, color: Colors.red),
-                                        onPressed: () {
-                                          if (item.id != null) {
+                                        onPressed: () async {
+                                          final confirmed = await ConfirmDeleteDialog.show(
+                                            context,
+                                            entityName: item.musicoNome ?? 'Músico',
+                                            message:
+                                                'Deseja remover ${item.musicoNome ?? "este músico"} da escala?\nEsta ação não pode ser desfeita.',
+                                          );
+                                          if (confirmed && context.mounted && item.id != null) {
                                             provider.deletarEscala(item.id!);
                                           }
                                         },

--- a/lib/views/musicas_page.dart
+++ b/lib/views/musicas_page.dart
@@ -5,6 +5,7 @@ import 'package:sggm/controllers/musicas_controller.dart';
 import 'package:sggm/models/artista.dart';
 import 'package:sggm/models/musicas.dart';
 import 'package:sggm/views/widgets/artista_selector_widget.dart';
+import 'package:sggm/views/widgets/dialogs/confirm_delete_dialog.dart';
 import 'package:sggm/views/widgets/loading/shimmer_list_tile.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -209,50 +210,36 @@ class _MusicasPageState extends State<MusicasPage> {
     }
   }
 
-  void _confirmarExclusao(Musica musica) {
-    showDialog(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Confirmar Exclusão'),
-        content: Text('Deseja realmente excluir "${musica.titulo}" de ${musica.artistaNome}?'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(),
-            child: const Text('Cancelar'),
-          ),
-          ElevatedButton(
-            onPressed: () async {
-              Navigator.of(ctx).pop();
-              try {
-                await Provider.of<MusicasProvider>(context, listen: false).deletarMusica(musica.id!);
-                if (context.mounted) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: Text('Música excluída com sucesso!'),
-                      backgroundColor: Colors.green,
-                    ),
-                  );
-                }
-              } catch (e) {
-                if (context.mounted) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: Text('Erro ao excluir música'),
-                      backgroundColor: Colors.red,
-                    ),
-                  );
-                }
-              }
-            },
-            style: ElevatedButton.styleFrom(
-              backgroundColor: Colors.red,
-              foregroundColor: Colors.white,
-            ),
-            child: const Text('Excluir'),
-          ),
-        ],
-      ),
+  void _confirmarExclusao(Musica musica) async {
+    final confirmed = await ConfirmDeleteDialog.show(
+      context,
+      entityName: musica.titulo,
+      message:
+          'Deseja realmente excluir "${musica.titulo}" de ${musica.artistaNome}?\nEsta ação não pode ser desfeita.',
     );
+
+    if (confirmed && context.mounted) {
+      try {
+        await Provider.of<MusicasProvider>(context, listen: false).deletarMusica(musica.id!);
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Música excluída com sucesso!'),
+              backgroundColor: Colors.green,
+            ),
+          );
+        }
+      } catch (e) {
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Erro ao excluir música'),
+              backgroundColor: Colors.red,
+            ),
+          );
+        }
+      }
+    }
   }
 
   @override

--- a/lib/views/musicos_page.dart
+++ b/lib/views/musicos_page.dart
@@ -5,6 +5,7 @@ import 'package:sggm/controllers/instrumentos_controller.dart';
 import 'package:sggm/controllers/musicos_controller.dart';
 import 'package:sggm/models/musicos.dart';
 import 'package:sggm/views/perfil_edit_page.dart';
+import 'package:sggm/views/widgets/dialogs/confirm_delete_dialog.dart';
 import 'package:sggm/views/widgets/loading/loading_overlay.dart';
 import 'package:sggm/views/widgets/loading/shimmer_list_tile.dart';
 
@@ -312,47 +313,34 @@ class _MusicosPageState extends State<MusicosPage> {
     }
   }
 
-  void _confirmarExclusao(Musico musico) {
-    showDialog(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Confirmar Exclusão'),
-        content: Text('Deseja realmente excluir ${musico.nome}?'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx),
-            child: const Text('Cancelar'),
-          ),
-          ElevatedButton(
-            onPressed: () async {
-              Navigator.pop(ctx);
-              try {
-                final sucesso = await Provider.of<MusicosProvider>(context, listen: false).deletarMusico(musico.id!);
-                if (context.mounted) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                      content: Text(sucesso ? 'Músico excluído com sucesso' : 'Erro ao excluir músico'),
-                      backgroundColor: sucesso ? Colors.green : Colors.red,
-                    ),
-                  );
-                }
-              } catch (e) {
-                if (context.mounted) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: Text('Erro ao excluir músico'),
-                      backgroundColor: Colors.red,
-                    ),
-                  );
-                }
-              }
-            },
-            style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
-            child: const Text('Excluir'),
-          ),
-        ],
-      ),
+  void _confirmarExclusao(Musico musico) async {
+    final confirmed = await ConfirmDeleteDialog.show(
+      context,
+      entityName: musico.nome,
     );
+
+    if (confirmed && context.mounted) {
+      try {
+        final sucesso = await Provider.of<MusicosProvider>(context, listen: false).deletarMusico(musico.id!);
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(sucesso ? 'Músico excluído com sucesso' : 'Erro ao excluir músico'),
+              backgroundColor: sucesso ? Colors.green : Colors.red,
+            ),
+          );
+        }
+      } catch (e) {
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Erro ao excluir músico'),
+              backgroundColor: Colors.red,
+            ),
+          );
+        }
+      }
+    }
   }
 
   @override

--- a/lib/views/widgets/dialogs/confirm_delete_dialog.dart
+++ b/lib/views/widgets/dialogs/confirm_delete_dialog.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+class ConfirmDeleteDialog extends StatelessWidget {
+  final String entityName;
+  final String? message;
+
+  const ConfirmDeleteDialog({
+    super.key,
+    required this.entityName,
+    this.message,
+  });
+
+  static Future<bool> show(
+    BuildContext context, {
+    required String entityName,
+    String? message,
+  }) async {
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (_) => ConfirmDeleteDialog(
+        entityName: entityName,
+        message: message,
+      ),
+    );
+    return result ?? false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Row(
+        children: [
+          Icon(Icons.warning_amber_rounded, color: Colors.red),
+          SizedBox(width: 8),
+          Text('Confirmar exclusão'),
+        ],
+      ),
+      content: Text(
+        message ?? 'Tem certeza que deseja excluir "$entityName"?\nEsta ação não pode ser desfeita.',
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context, false),
+          child: const Text('Cancelar'),
+        ),
+        ElevatedButton(
+          style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
+          onPressed: () => Navigator.pop(context, true),
+          child: const Text('Excluir'),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## O que foi feito
Implementado widget reutilizável `ConfirmDeleteDialog` e aplicado em todas as telas com ação de exclusão.

## Arquivos alterados
- `lib/views/widgets/dialogs/confirm_delete_dialog.dart` — widget novo reutilizável
- `lib/views/evento_detalhes_page.dart` — confirmação ao remover músico da escala
- `lib/views/musicos_page.dart` — padronizado com ConfirmDeleteDialog
- `lib/views/escalas_page.dart` — padronizado com ConfirmDeleteDialog
- `lib/views/musicas_page.dart` — padronizado com ConfirmDeleteDialog

## Critérios atendidos
- [x] ConfirmDeleteDialog criado com variantes de mensagem
- [x] Nenhuma exclusão ocorre sem confirmação do usuário
- [x] Mensagem clara com nome da entidade sendo excluída
- [x] Ação não pode ser desfeita informada ao usuário
- [x] Todos os controllers só executam delete após confirmação

closes #27
