### PR TITLE
Adiciona data_hora_ensaio na escala (model, controller e UI)

### DIFF
--- a/lib/controllers/escalas_controller.dart
+++ b/lib/controllers/escalas_controller.dart
@@ -192,6 +192,7 @@ class EscalasProvider extends ChangeNotifier {
             confirmado: confirmado,
             criadoEm: escalaAtual.criadoEm,
             eventoId: escalaAtual.eventoId,
+            dataHoraEnsaio: escalaAtual.dataHoraEnsaio,
           );
           AppLogger.info('Presença ${confirmado ? "confirmada" : "desconfirmada"} na escala $escalaId');
         }

--- a/lib/models/escalas.dart
+++ b/lib/models/escalas.dart
@@ -9,34 +9,35 @@ class Escala {
   final String? observacao;
   final bool confirmado;
   final DateTime? criadoEm;
+  final DateTime? dataHoraEnsaio;
 
-  Escala(
-      {this.id,
-      required this.musicoId,
-      required this.eventoId,
-      this.musicoNome,
-      this.eventoNome,
-      this.instrumentoNoEvento,
-      this.observacao,
-      this.confirmado = false,
-      this.criadoEm,
-      this.instrumentoNome});
+  Escala({
+    this.id,
+    required this.musicoId,
+    required this.eventoId,
+    this.musicoNome,
+    this.eventoNome,
+    this.instrumentoNoEvento,
+    this.observacao,
+    this.confirmado = false,
+    this.criadoEm,
+    this.instrumentoNome,
+    this.dataHoraEnsaio,
+  });
 
   factory Escala.fromJson(Map<String, dynamic> json) {
     return Escala(
       id: json['id'],
-      // O Backend envia 'musico' e 'evento' como IDs (Foreign Keys)
       musicoId: json['musico'],
       eventoId: json['evento'],
-
       musicoNome: json['musico_nome'],
       eventoNome: json['evento_nome'],
-
       observacao: json['observacao'],
       instrumentoNoEvento: json['instrumento_no_evento'],
       instrumentoNome: json['instrumento_nome'],
       confirmado: json['confirmado'] ?? false,
       criadoEm: json['criado_em'] != null ? DateTime.parse(json['criado_em']) : null,
+      dataHoraEnsaio: json['data_hora_ensaio'] != null ? DateTime.parse(json['data_hora_ensaio']) : null,
     );
   }
 
@@ -45,9 +46,9 @@ class Escala {
       if (id != null) 'id': id,
       'musico': musicoId,
       'evento': eventoId,
-      'instrumento_no_evento':
-          instrumentoNoEvento != null ? instrumentoNoEvento.toString() : '', // Backend aceita string ou ID
+      'instrumento_no_evento': instrumentoNoEvento != null ? instrumentoNoEvento.toString() : '',
       'observacao': observacao ?? '',
+      if (dataHoraEnsaio != null) 'data_hora_ensaio': dataHoraEnsaio!.toIso8601String(),
     };
   }
 }

--- a/lib/views/escalas_page.dart
+++ b/lib/views/escalas_page.dart
@@ -87,6 +87,7 @@ class _EscalasPageState extends State<EscalasPage> {
     int? selectedEventoId;
     String? selectedInstrumento;
     bool mostrarCampoOutro = false;
+    DateTime? dataHoraEnsaio;
 
     showDialog(
       context: context,
@@ -215,6 +216,55 @@ class _EscalasPageState extends State<EscalasPage> {
                       ),
                     ],
                     const SizedBox(height: 16),
+                    InkWell(
+                      onTap: () async {
+                        final data = await showDatePicker(
+                          context: context,
+                          initialDate: dataHoraEnsaio ?? DateTime.now(),
+                          firstDate: DateTime(2020),
+                          lastDate: DateTime(2030),
+                        );
+                        if (data == null) return;
+
+                        final hora = await showTimePicker(
+                          context: context,
+                          initialTime:
+                              dataHoraEnsaio != null ? TimeOfDay.fromDateTime(dataHoraEnsaio!) : TimeOfDay.now(),
+                        );
+                        if (hora == null) return;
+
+                        setStateDialog(() {
+                          dataHoraEnsaio = DateTime(
+                            data.year,
+                            data.month,
+                            data.day,
+                            hora.hour,
+                            hora.minute,
+                          );
+                        });
+                      },
+                      child: InputDecorator(
+                        decoration: const InputDecoration(
+                          labelText: 'Data e hora do ensaio (opcional)',
+                          border: OutlineInputBorder(),
+                          contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                          suffixIcon: Icon(Icons.calendar_month_outlined),
+                        ),
+                        child: Text(
+                          dataHoraEnsaio != null
+                              ? '${dataHoraEnsaio!.day.toString().padLeft(2, '0')}/'
+                                  '${dataHoraEnsaio!.month.toString().padLeft(2, '0')}/'
+                                  '${dataHoraEnsaio!.year}  '
+                                  '${dataHoraEnsaio!.hour.toString().padLeft(2, '0')}:'
+                                  '${dataHoraEnsaio!.minute.toString().padLeft(2, '0')}'
+                              : 'Toque para selecionar',
+                          style: TextStyle(
+                            color: dataHoraEnsaio != null ? Colors.black87 : Colors.grey[500],
+                          ),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 16),
                     TextField(
                       controller: obsController,
                       decoration: const InputDecoration(
@@ -264,6 +314,7 @@ class _EscalasPageState extends State<EscalasPage> {
                               eventoId: selectedEventoId!,
                               instrumentoNoEvento: instrumentoIdFinal,
                               observacao: obsController.text,
+                              dataHoraEnsaio: dataHoraEnsaio,
                             );
 
                             try {
@@ -380,6 +431,16 @@ class _EscalasPageState extends State<EscalasPage> {
             ),
             const Divider(height: 24),
             _buildInfoRow(Icons.person, escala.musicoNome ?? 'Músico #${escala.musicoId}'),
+            if (escala.dataHoraEnsaio != null)
+              _buildInfoRow(
+                Icons.event_available,
+                'Ensaio: '
+                '${escala.dataHoraEnsaio!.day.toString().padLeft(2, '0')}/'
+                '${escala.dataHoraEnsaio!.month.toString().padLeft(2, '0')}/'
+                '${escala.dataHoraEnsaio!.year}  '
+                '${escala.dataHoraEnsaio!.hour.toString().padLeft(2, '0')}:'
+                '${escala.dataHoraEnsaio!.minute.toString().padLeft(2, '0')}',
+              ),
             if (escala.instrumentoNoEvento != null) _buildInfoRow(Icons.music_note, escala.instrumentoNome.toString()),
             if (escala.observacao != null && escala.observacao!.isNotEmpty)
               _buildInfoRow(Icons.note, escala.observacao!),

--- a/test/unit/controllers/escalas_controller_test.dart
+++ b/test/unit/controllers/escalas_controller_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sggm/controllers/escalas_controller.dart';
+
+void main() {
+  late EscalasProvider escalasProvider;
+
+  setUp(() {
+    escalasProvider = EscalasProvider();
+  });
+
+  group('EscalasProvider - Estado inicial', () {
+    test('lista de escalas começa vazia', () {
+      expect(escalasProvider.escalas, isEmpty);
+    });
+
+    test('não está carregando por padrão', () {
+      expect(escalasProvider.isLoading, false);
+    });
+
+    test('errorMessage é null por padrão', () {
+      expect(escalasProvider.errorMessage, null);
+    });
+  });
+
+  group('EscalasProvider - limpar()', () {
+    test('limpa estado completamente', () {
+      escalasProvider.limpar();
+      expect(escalasProvider.escalas, isEmpty);
+      expect(escalasProvider.errorMessage, null);
+      expect(escalasProvider.isLoading, false);
+    });
+  });
+
+  group('EscalasProvider - limparErro()', () {
+    test('limpa errorMessage sem exceções', () {
+      expect(() => escalasProvider.limparErro(), returnsNormally);
+      expect(escalasProvider.errorMessage, null);
+    });
+  });
+}

--- a/test/unit/models/escala_model_test.dart
+++ b/test/unit/models/escala_model_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sggm/models/escalas.dart';
+
+void main() {
+  group('Escala.fromJson', () {
+    test('deserializa data_hora_ensaio quando presente', () {
+      final json = {
+        'id': 1,
+        'musico': 10,
+        'evento': 20,
+        'musico_nome': 'Erickson',
+        'evento_nome': 'Culto',
+        'confirmado': false,
+        'data_hora_ensaio': '2026-03-10T18:00:00',
+      };
+
+      final escala = Escala.fromJson(json);
+
+      expect(escala.dataHoraEnsaio, isNotNull);
+      expect(escala.dataHoraEnsaio, equals(DateTime.parse('2026-03-10T18:00:00')));
+    });
+
+    test('data_hora_ensaio fica null quando ausente no JSON', () {
+      final json = {
+        'id': 1,
+        'musico': 10,
+        'evento': 20,
+        'musico_nome': 'Erickson',
+        'evento_nome': 'Culto',
+        'confirmado': false,
+      };
+
+      final escala = Escala.fromJson(json);
+
+      expect(escala.dataHoraEnsaio, isNull);
+    });
+
+    test('data_hora_ensaio fica null quando valor é null no JSON', () {
+      final json = {
+        'id': 1,
+        'musico': 10,
+        'evento': 20,
+        'confirmado': false,
+        'data_hora_ensaio': null,
+      };
+
+      final escala = Escala.fromJson(json);
+
+      expect(escala.dataHoraEnsaio, isNull);
+    });
+  });
+
+  group('Escala.toJson', () {
+    test('serializa data_hora_ensaio no formato ISO 8601 quando preenchido', () {
+      final dataEnsaio = DateTime(2026, 3, 10, 18, 0, 0);
+      final escala = Escala(
+        musicoId: 10,
+        eventoId: 20,
+        dataHoraEnsaio: dataEnsaio,
+      );
+
+      final json = escala.toJson();
+
+      expect(json['data_hora_ensaio'], isNotNull);
+      expect(json['data_hora_ensaio'], equals(dataEnsaio.toIso8601String()));
+    });
+
+    test('não inclui data_hora_ensaio no JSON quando null', () {
+      final escala = Escala(
+        musicoId: 10,
+        eventoId: 20,
+      );
+
+      final json = escala.toJson();
+
+      expect(json.containsKey('data_hora_ensaio'), isFalse);
+    });
+  });
+
+  group('Escala - estado inicial', () {
+    test('dataHoraEnsaio é null por padrão', () {
+      final escala = Escala(musicoId: 1, eventoId: 2);
+      expect(escala.dataHoraEnsaio, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## O que foi feito

Implementação completa do campo \`data_hora_ensaio\` na escala mobile, seguindo o mesmo ciclo TDD aplicado no backend.

## Ciclo TDD aplicado

### 🔴 RED — Testes criados antes da implementação
- \`test/unit/models/escala_model_test.dart\`
- \`test/unit/controllers/escalas_controller_test.dart\`

### 🟢 GREEN — Implementação mínima para passar os testes
- \`lib/models/escalas.dart\`
- \`lib/controllers/escalas_controller.dart\`

### 🔵 REFACTOR — UI
- \`lib/views/escalas_page.dart\` — DateTimePicker + exibição no card

## Critérios atendidos
- [x] \`data_hora_ensaio\` deserializado corretamente do JSON da API
- [x] Serializado em ISO 8601 no envio
- [x] Campo omitido quando \`null\` (não quebra escalas sem ensaio)
- [x] DateTimePicker com seletor de data e hora
- [x] Data formatada exibida no card
- [x] Campo opcional — criação sem data continua funcionando
- [x] Todos os testes unitários passando

closes #6