### PR TITLE
feat: editar música e abrir detalhes ao tocar no card do repertório

### DIFF
--- a/lib/views/widgets/artista_selector_widget.dart
+++ b/lib/views/widgets/artista_selector_widget.dart
@@ -45,6 +45,17 @@ class _ArtistaSelectorWidgetState extends State<ArtistaSelectorWidget> {
       final artistas = await _artistaService.listarArtistas(busca: busca);
       if (mounted) {
         setState(() => _artistas = artistas);
+        if (_artistaSelecionado != null && _artistas.isNotEmpty) {
+          final match = _artistas
+              .where(
+                (a) => a.id == _artistaSelecionado!.id,
+              )
+              .toList();
+          if (match.isNotEmpty) {
+            _artistaSelecionado = match.first;
+            widget.onArtistaSelected(_artistaSelecionado!);
+          }
+        }
       }
     } catch (e) {
       if (mounted) {
@@ -158,7 +169,7 @@ class _ArtistaSelectorWidgetState extends State<ArtistaSelectorWidget> {
           )
         else
           DropdownButtonFormField<Artista>(
-            initialValue: _artistaSelecionado,
+            value: _artistas.contains(_artistaSelecionado) ? _artistaSelecionado : null,
             decoration: InputDecoration(
               labelText: 'Selecione o Artista',
               border: OutlineInputBorder(

--- a/lib/views/widgets/buttons/app_button.dart
+++ b/lib/views/widgets/buttons/app_button.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+
+enum AppButtonVariant { primary, secondary, danger, ghost }
+
+enum AppButtonSize { small, medium, large }
+
+class AppButton extends StatelessWidget {
+  final String label;
+  final VoidCallback? onPressed;
+  final IconData? icon;
+  final bool isLoading;
+  final AppButtonVariant variant;
+  final AppButtonSize size;
+  final bool fullWidth;
+  final TextStyle? textStyle;
+
+  const AppButton(
+      {super.key,
+      required this.label,
+      this.onPressed,
+      this.icon,
+      this.isLoading = false,
+      this.variant = AppButtonVariant.primary,
+      this.size = AppButtonSize.medium,
+      this.fullWidth = true,
+      this.textStyle});
+
+  double get _height => switch (size) {
+        AppButtonSize.small => 40.0,
+        AppButtonSize.medium => 52.0,
+        AppButtonSize.large => 60.0,
+      };
+
+  double get _fontSize => size == AppButtonSize.small ? 14.0 : 16.0;
+
+  Widget _buildChild(BuildContext context) {
+    if (isLoading) {
+      return SizedBox(
+        height: 22,
+        width: 22,
+        child: CircularProgressIndicator(
+          strokeWidth: 2.5,
+          valueColor: AlwaysStoppedAnimation<Color>(
+            variant == AppButtonVariant.primary || variant == AppButtonVariant.danger
+                ? Colors.white
+                : Theme.of(context).primaryColor,
+          ),
+        ),
+      );
+    }
+
+    if (icon != null) {
+      return Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 20),
+          const SizedBox(width: 8),
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: _fontSize,
+              fontWeight: FontWeight.w600,
+              letterSpacing: 0.5,
+            ),
+          ),
+        ],
+      );
+    }
+
+    final effectiveStyle = TextStyle(
+      fontSize: _fontSize,
+      fontWeight: FontWeight.w600,
+      letterSpacing: 0.5,
+    ).merge(textStyle);
+
+    return Text(label, style: effectiveStyle);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final effectiveOnPressed = isLoading ? null : onPressed;
+    final child = _buildChild(context);
+
+    Widget button = switch (variant) {
+      AppButtonVariant.primary => ElevatedButton(
+          onPressed: effectiveOnPressed,
+          child: child,
+        ),
+      AppButtonVariant.secondary => OutlinedButton(
+          onPressed: effectiveOnPressed,
+          child: child,
+        ),
+      AppButtonVariant.danger => ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            backgroundColor: Theme.of(context).colorScheme.error,
+            foregroundColor: Colors.white,
+          ),
+          onPressed: effectiveOnPressed,
+          child: child,
+        ),
+      AppButtonVariant.ghost => TextButton(
+          onPressed: effectiveOnPressed,
+          child: child,
+        ),
+    };
+
+    return SizedBox(
+      width: fullWidth ? double.infinity : null,
+      height: _height,
+      child: button,
+    );
+  }
+}

--- a/test/views/widgets/buttons/app_button_test.dart
+++ b/test/views/widgets/buttons/app_button_test.dart
@@ -1,0 +1,259 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sggm/views/widgets/buttons/app_button.dart';
+
+// Helper para montar o widget isolado
+Widget _buildApp(Widget child) {
+  return MaterialApp(
+    home: Scaffold(body: Center(child: child)),
+  );
+}
+
+void main() {
+  group('AppButton', () {
+    // ─── VARIANT: primary ────────────────────────────────────────────
+    group('variant primary', () {
+      testWidgets('renderiza ElevatedButton por padrão', (tester) async {
+        await tester.pumpWidget(_buildApp(
+          AppButton(label: 'Salvar', onPressed: () {}),
+        ));
+        expect(find.byType(ElevatedButton), findsOneWidget);
+      });
+
+      testWidgets('exibe o label corretamente', (tester) async {
+        await tester.pumpWidget(_buildApp(
+          AppButton(label: 'Salvar', onPressed: () {}),
+        ));
+        expect(find.text('Salvar'), findsOneWidget);
+      });
+    });
+
+    // ─── VARIANT: secondary ──────────────────────────────────────────
+    group('variant secondary', () {
+      testWidgets('renderiza OutlinedButton', (tester) async {
+        await tester.pumpWidget(_buildApp(
+          AppButton(
+            label: 'Cancelar',
+            variant: AppButtonVariant.secondary,
+            onPressed: () {},
+          ),
+        ));
+        expect(find.byType(OutlinedButton), findsOneWidget);
+      });
+    });
+
+    // ─── VARIANT: danger ─────────────────────────────────────────────
+    group('variant danger', () {
+      testWidgets('renderiza ElevatedButton', (tester) async {
+        await tester.pumpWidget(_buildApp(
+          AppButton(
+            label: 'Excluir',
+            variant: AppButtonVariant.danger,
+            onPressed: () {},
+          ),
+        ));
+        expect(find.byType(ElevatedButton), findsOneWidget);
+      });
+    });
+
+    // ─── VARIANT: ghost ──────────────────────────────────────────────
+    group('variant ghost', () {
+      testWidgets('renderiza TextButton', (tester) async {
+        await tester.pumpWidget(_buildApp(
+          AppButton(
+            label: 'Voltar',
+            variant: AppButtonVariant.ghost,
+            onPressed: () {},
+          ),
+        ));
+        expect(find.byType(TextButton), findsOneWidget);
+      });
+    });
+
+    // ─── TAMANHOS / ALTURA ────────────────────────────────────────────
+    group('tamanhos', () {
+      testWidgets('size small tem altura 40', (tester) async {
+        await tester.pumpWidget(_buildApp(
+          AppButton(
+            label: 'Btn',
+            size: AppButtonSize.small,
+            onPressed: () {},
+          ),
+        ));
+        final sizedBox = tester.widget<SizedBox>(
+          find
+              .descendant(
+                of: find.byType(AppButton),
+                matching: find.byType(SizedBox),
+              )
+              .first,
+        );
+        expect(sizedBox.height, 40.0);
+      });
+
+      testWidgets('size medium tem altura 52 (padrão)', (tester) async {
+        await tester.pumpWidget(_buildApp(
+          AppButton(label: 'Btn', onPressed: () {}),
+        ));
+        final sizedBox = tester.widget<SizedBox>(
+          find
+              .descendant(
+                of: find.byType(AppButton),
+                matching: find.byType(SizedBox),
+              )
+              .first,
+        );
+        expect(sizedBox.height, 52.0);
+      });
+
+      testWidgets('size large tem altura 60', (tester) async {
+        await tester.pumpWidget(_buildApp(
+          AppButton(
+            label: 'Btn',
+            size: AppButtonSize.large,
+            onPressed: () {},
+          ),
+        ));
+        final sizedBox = tester.widget<SizedBox>(
+          find
+              .descendant(
+                of: find.byType(AppButton),
+                matching: find.byType(SizedBox),
+              )
+              .first,
+        );
+        expect(sizedBox.height, 60.0);
+      });
+    });
+
+    // ─── fullWidth ────────────────────────────────────────────────────
+    group('fullWidth', () {
+      testWidgets('fullWidth true → SizedBox.width é double.infinity', (tester) async {
+        await tester.pumpWidget(_buildApp(
+          AppButton(label: 'Btn', onPressed: () {}, fullWidth: true),
+        ));
+        final sizedBox = tester.widget<SizedBox>(
+          find
+              .descendant(
+                of: find.byType(AppButton),
+                matching: find.byType(SizedBox),
+              )
+              .first,
+        );
+        expect(sizedBox.width, double.infinity);
+      });
+
+      testWidgets('fullWidth false → SizedBox.width é null', (tester) async {
+        await tester.pumpWidget(_buildApp(
+          AppButton(label: 'Btn', onPressed: () {}, fullWidth: false),
+        ));
+        final sizedBox = tester.widget<SizedBox>(
+          find
+              .descendant(
+                of: find.byType(AppButton),
+                matching: find.byType(SizedBox),
+              )
+              .first,
+        );
+        expect(sizedBox.width, isNull);
+      });
+    });
+
+    // ─── ESTADO DESABILITADO ──────────────────────────────────────────
+    group('estado desabilitado', () {
+      testWidgets('onPressed null desabilita o botão', (tester) async {
+        await tester.pumpWidget(_buildApp(
+          const AppButton(label: 'Salvar', onPressed: null),
+        ));
+        final btn = tester.widget<ElevatedButton>(find.byType(ElevatedButton));
+        expect(btn.onPressed, isNull);
+      });
+
+      testWidgets('isLoading true desabilita o botão', (tester) async {
+        await tester.pumpWidget(_buildApp(
+          AppButton(label: 'Salvar', isLoading: true, onPressed: () {}),
+        ));
+        final btn = tester.widget<ElevatedButton>(find.byType(ElevatedButton));
+        expect(btn.onPressed, isNull);
+      });
+    });
+
+    // ─── ESTADO DE LOADING ────────────────────────────────────────────
+    group('estado de loading', () {
+      testWidgets('isLoading true exibe CircularProgressIndicator', (tester) async {
+        await tester.pumpWidget(_buildApp(
+          AppButton(label: 'Salvar', isLoading: true, onPressed: () {}),
+        ));
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      });
+
+      testWidgets('isLoading true NÃO exibe o label', (tester) async {
+        await tester.pumpWidget(_buildApp(
+          AppButton(label: 'Salvar', isLoading: true, onPressed: () {}),
+        ));
+        expect(find.text('Salvar'), findsNothing);
+      });
+
+      testWidgets('isLoading false exibe o label normalmente', (tester) async {
+        await tester.pumpWidget(_buildApp(
+          AppButton(label: 'Salvar', isLoading: false, onPressed: () {}),
+        ));
+        expect(find.text('Salvar'), findsOneWidget);
+        expect(find.byType(CircularProgressIndicator), findsNothing);
+      });
+    });
+
+    // ─── ÍCONE ────────────────────────────────────────────────────────
+    group('ícone', () {
+      testWidgets('icon não nulo exibe Icon widget', (tester) async {
+        await tester.pumpWidget(_buildApp(
+          AppButton(
+            label: 'Salvar',
+            icon: Icons.save,
+            onPressed: () {},
+          ),
+        ));
+        expect(find.byIcon(Icons.save), findsOneWidget);
+      });
+
+      testWidgets('icon nulo NÃO exibe Icon widget', (tester) async {
+        await tester.pumpWidget(_buildApp(
+          AppButton(label: 'Salvar', onPressed: () {}),
+        ));
+        expect(find.byType(Icon), findsNothing);
+      });
+    });
+
+    // ─── CALLBACK ─────────────────────────────────────────────────────
+    group('callback', () {
+      testWidgets('chama onPressed ao tocar', (tester) async {
+        var chamado = false;
+        await tester.pumpWidget(_buildApp(
+          AppButton(label: 'Salvar', onPressed: () => chamado = true),
+        ));
+        await tester.tap(find.byType(ElevatedButton));
+        expect(chamado, isTrue);
+      });
+
+      testWidgets('NÃO chama onPressed quando desabilitado', (tester) async {
+        var chamado = false;
+        await tester.pumpWidget(_buildApp(
+          const AppButton(label: 'Salvar', onPressed: null),
+        ));
+        await tester.tap(find.byType(ElevatedButton), warnIfMissed: false);
+        expect(chamado, isFalse);
+      });
+    });
+  });
+
+  group('textStyle', () {
+    testWidgets('textStyle customizado é aplicado ao label', (tester) async {
+      const style = TextStyle(fontFamily: 'Inknut_Antiqua', fontSize: 18);
+      await tester.pumpWidget(_buildApp(
+        AppButton(label: 'Entrar', onPressed: () {}, textStyle: style),
+      ));
+      final text = tester.widget<Text>(find.text('Entrar'));
+      expect(text.style?.fontFamily, 'Inknut_Antiqua');
+    });
+  });
+}


### PR DESCRIPTION
## O que foi feito

Melhoria de UX na tela de Repertório (`musicas_page.dart`).

## Mudanças

### 🎵 Card da música
- `onTap` agora navega para `MusicaDetalhesPage` (vídeo + cifra)
- Antes abria a cifra diretamente no navegador externo

### ✏️ Editar música
- `⋮` (PopupMenu) agora tem opção **Editar**
- Dialog pré-preenchido com: título, artista, tom, link cifra e link YouTube
- Chama `atualizarMusica` no `MusicasProvider`

### 🐛 Fix — ArtistaSelectorWidget
- Dropdown não quebra mais ao abrir dialog de edição
- Artista inicial é re-selecionado após lista carregar da API
- Corrige `AssertionError` do `DropdownButtonFormField`

## Arquivos alterados
- `lib/views/musicas_page.dart`
- `lib/views/widgets/artista_selector_widget.dart`

## Critérios atendidos
- [x] Toque no card abre `MusicaDetalhesPage`
- [x] `⋮` → Editar abre dialog com dados pré-preenchidos
- [x] `⋮` → Excluir mantém `ConfirmDeleteDialog`
- [x] Artista pré-selecionado corretamente no dialog de edição
- [x] Músico comum (não líder) também acessa os detalhes pelo card
