### PR TITLE
feat: move dataHoraEnsaio de Escala para Evento

### DIFF
--- a/lib/controllers/escalas_controller.dart
+++ b/lib/controllers/escalas_controller.dart
@@ -192,7 +192,6 @@ class EscalasProvider extends ChangeNotifier {
             confirmado: confirmado,
             criadoEm: escalaAtual.criadoEm,
             eventoId: escalaAtual.eventoId,
-            dataHoraEnsaio: escalaAtual.dataHoraEnsaio,
           );
           AppLogger.info('Presença ${confirmado ? "confirmada" : "desconfirmada"} na escala $escalaId');
         }

--- a/lib/models/escalas.dart
+++ b/lib/models/escalas.dart
@@ -9,7 +9,6 @@ class Escala {
   final String? observacao;
   final bool confirmado;
   final DateTime? criadoEm;
-  final DateTime? dataHoraEnsaio;
 
   Escala({
     this.id,
@@ -22,7 +21,6 @@ class Escala {
     this.confirmado = false,
     this.criadoEm,
     this.instrumentoNome,
-    this.dataHoraEnsaio,
   });
 
   factory Escala.fromJson(Map<String, dynamic> json) {
@@ -37,7 +35,6 @@ class Escala {
       instrumentoNome: json['instrumento_nome'],
       confirmado: json['confirmado'] ?? false,
       criadoEm: json['criado_em'] != null ? DateTime.parse(json['criado_em']) : null,
-      dataHoraEnsaio: json['data_hora_ensaio'] != null ? DateTime.parse(json['data_hora_ensaio']) : null,
     );
   }
 
@@ -48,7 +45,6 @@ class Escala {
       'evento': eventoId,
       'instrumento_no_evento': instrumentoNoEvento != null ? instrumentoNoEvento.toString() : '',
       'observacao': observacao ?? '',
-      if (dataHoraEnsaio != null) 'data_hora_ensaio': dataHoraEnsaio!.toIso8601String(),
     };
   }
 }

--- a/lib/models/eventos.dart
+++ b/lib/models/eventos.dart
@@ -11,6 +11,7 @@ class Evento {
   final List<Musica>? repertorio;
   final List<Escala>? escalas;
   final DateTime? criadoEm;
+  final DateTime? dataHoraEnsaio; // ← NOVO
 
   Evento({
     this.id,
@@ -22,6 +23,7 @@ class Evento {
     this.tipo = 'evento',
     this.descricao,
     this.repertorio,
+    this.dataHoraEnsaio,
   });
 
   factory Evento.fromJson(Map<String, dynamic> json) {
@@ -42,6 +44,7 @@ class Evento {
       tipo: json['tipo'] ?? 'CULTO',
       escalas: (json['escalas'] as List?)?.map((e) => Escala.fromJson(e)).toList(),
       criadoEm: json['criado_em'] != null ? DateTime.parse(json['criado_em']) : null,
+      dataHoraEnsaio: json['data_hora_ensaio'] != null ? DateTime.parse(json['data_hora_ensaio']) : null,
     );
   }
 
@@ -52,6 +55,7 @@ class Evento {
       'data_evento': dataEvento,
       'local': local,
       'descricao': descricao,
+      if (dataHoraEnsaio != null) 'data_hora_ensaio': dataHoraEnsaio!.toIso8601String(),
     };
   }
 }

--- a/lib/views/escalas_page.dart
+++ b/lib/views/escalas_page.dart
@@ -87,7 +87,6 @@ class _EscalasPageState extends State<EscalasPage> {
     int? selectedEventoId;
     String? selectedInstrumento;
     bool mostrarCampoOutro = false;
-    DateTime? dataHoraEnsaio;
 
     showDialog(
       context: context,
@@ -216,55 +215,6 @@ class _EscalasPageState extends State<EscalasPage> {
                       ),
                     ],
                     const SizedBox(height: 16),
-                    InkWell(
-                      onTap: () async {
-                        final data = await showDatePicker(
-                          context: context,
-                          initialDate: dataHoraEnsaio ?? DateTime.now(),
-                          firstDate: DateTime(2020),
-                          lastDate: DateTime(2030),
-                        );
-                        if (data == null) return;
-
-                        final hora = await showTimePicker(
-                          context: context,
-                          initialTime:
-                              dataHoraEnsaio != null ? TimeOfDay.fromDateTime(dataHoraEnsaio!) : TimeOfDay.now(),
-                        );
-                        if (hora == null) return;
-
-                        setStateDialog(() {
-                          dataHoraEnsaio = DateTime(
-                            data.year,
-                            data.month,
-                            data.day,
-                            hora.hour,
-                            hora.minute,
-                          );
-                        });
-                      },
-                      child: InputDecorator(
-                        decoration: const InputDecoration(
-                          labelText: 'Data e hora do ensaio (opcional)',
-                          border: OutlineInputBorder(),
-                          contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                          suffixIcon: Icon(Icons.calendar_month_outlined),
-                        ),
-                        child: Text(
-                          dataHoraEnsaio != null
-                              ? '${dataHoraEnsaio!.day.toString().padLeft(2, '0')}/'
-                                  '${dataHoraEnsaio!.month.toString().padLeft(2, '0')}/'
-                                  '${dataHoraEnsaio!.year}  '
-                                  '${dataHoraEnsaio!.hour.toString().padLeft(2, '0')}:'
-                                  '${dataHoraEnsaio!.minute.toString().padLeft(2, '0')}'
-                              : 'Toque para selecionar',
-                          style: TextStyle(
-                            color: dataHoraEnsaio != null ? Colors.black87 : Colors.grey[500],
-                          ),
-                        ),
-                      ),
-                    ),
-                    const SizedBox(height: 16),
                     TextField(
                       controller: obsController,
                       decoration: const InputDecoration(
@@ -314,7 +264,6 @@ class _EscalasPageState extends State<EscalasPage> {
                               eventoId: selectedEventoId!,
                               instrumentoNoEvento: instrumentoIdFinal,
                               observacao: obsController.text,
-                              dataHoraEnsaio: dataHoraEnsaio,
                             );
 
                             try {
@@ -431,16 +380,6 @@ class _EscalasPageState extends State<EscalasPage> {
             ),
             const Divider(height: 24),
             _buildInfoRow(Icons.person, escala.musicoNome ?? 'Músico #${escala.musicoId}'),
-            if (escala.dataHoraEnsaio != null)
-              _buildInfoRow(
-                Icons.event_available,
-                'Ensaio: '
-                '${escala.dataHoraEnsaio!.day.toString().padLeft(2, '0')}/'
-                '${escala.dataHoraEnsaio!.month.toString().padLeft(2, '0')}/'
-                '${escala.dataHoraEnsaio!.year}  '
-                '${escala.dataHoraEnsaio!.hour.toString().padLeft(2, '0')}:'
-                '${escala.dataHoraEnsaio!.minute.toString().padLeft(2, '0')}',
-              ),
             if (escala.instrumentoNoEvento != null) _buildInfoRow(Icons.music_note, escala.instrumentoNome.toString()),
             if (escala.observacao != null && escala.observacao!.isNotEmpty)
               _buildInfoRow(Icons.note, escala.observacao!),

--- a/lib/views/eventos_page.dart
+++ b/lib/views/eventos_page.dart
@@ -40,6 +40,7 @@ class _EventosPageState extends State<EventosPage> {
   void _mostrarDialogoAdicionar(BuildContext context) {
     final nomeController = TextEditingController(text: 'Culto');
     final localController = TextEditingController(text: 'IPB Ponta Porã');
+    DateTime? dataHoraEnsaio;
     DateTime dataSelecionada = DateTime.now();
     TimeOfDay horarioSelecionado = TimeOfDay.now();
 
@@ -121,6 +122,61 @@ class _EventosPageState extends State<EventosPage> {
                     ),
                   ),
                 ),
+                const SizedBox(height: 12),
+                InkWell(
+                  onTap: () async {
+                    final data = await showDatePicker(
+                      context: context,
+                      initialDate: dataHoraEnsaio ?? dataSelecionada,
+                      firstDate: DateTime(2020),
+                      lastDate: DateTime(2030),
+                      helpText: 'Data do ensaio',
+                      cancelText: 'Cancelar',
+                      confirmText: 'Confirmar',
+                    );
+                    if (data == null) return;
+                    final hora = await showTimePicker(
+                      context: context,
+                      initialTime: dataHoraEnsaio != null ? TimeOfDay.fromDateTime(dataHoraEnsaio!) : TimeOfDay.now(),
+                    );
+                    if (hora == null) return;
+                    setState(() {
+                      dataHoraEnsaio = DateTime(
+                        data.year,
+                        data.month,
+                        data.day,
+                        hora.hour,
+                        hora.minute,
+                      );
+                    });
+                  },
+                  child: InputDecorator(
+                    decoration: InputDecoration(
+                      labelText: 'Data e hora do ensaio (opcional)',
+                      border: const OutlineInputBorder(),
+                      suffixIcon: const Icon(Icons.event_available),
+                      // botão para limpar
+                      suffix: dataHoraEnsaio != null
+                          ? GestureDetector(
+                              onTap: () => setState(() => dataHoraEnsaio = null),
+                              child: const Icon(Icons.close, size: 18),
+                            )
+                          : null,
+                    ),
+                    child: Text(
+                      dataHoraEnsaio != null
+                          ? '${dataHoraEnsaio!.day.toString().padLeft(2, '0')}/'
+                              '${dataHoraEnsaio!.month.toString().padLeft(2, '0')}/'
+                              '${dataHoraEnsaio!.year}  '
+                              '${dataHoraEnsaio!.hour.toString().padLeft(2, '0')}:'
+                              '${dataHoraEnsaio!.minute.toString().padLeft(2, '0')}'
+                          : 'Toque para selecionar (opcional)',
+                      style: TextStyle(
+                        color: dataHoraEnsaio != null ? Colors.black87 : Colors.grey[500],
+                      ),
+                    ),
+                  ),
+                ),
               ],
             ),
           ),
@@ -154,6 +210,7 @@ class _EventosPageState extends State<EventosPage> {
                   local: localController.text,
                   dataEvento: dataComHorario.toIso8601String(),
                   descricao: 'Criado via App',
+                  dataHoraEnsaio: dataHoraEnsaio,
                 );
 
                 try {
@@ -260,6 +317,22 @@ class _EventosPageState extends State<EventosPage> {
                             Text(evento.local),
                           ],
                         ),
+                        if (evento.dataHoraEnsaio != null)
+                          Row(
+                            children: [
+                              const Icon(Icons.event_available, size: 14, color: Colors.grey),
+                              const SizedBox(width: 4),
+                              Text(
+                                'Ensaio: '
+                                '${evento.dataHoraEnsaio!.day.toString().padLeft(2, '0')}/'
+                                '${evento.dataHoraEnsaio!.month.toString().padLeft(2, '0')}/'
+                                '${evento.dataHoraEnsaio!.year}  '
+                                '${evento.dataHoraEnsaio!.hour.toString().padLeft(2, '0')}:'
+                                '${evento.dataHoraEnsaio!.minute.toString().padLeft(2, '0')}',
+                                style: const TextStyle(fontSize: 12, color: Colors.grey),
+                              ),
+                            ],
+                          ),
                       ],
                     ),
                     trailing: const Icon(Icons.arrow_forward_ios, size: 16),

--- a/test/unit/models/escala_model_test.dart
+++ b/test/unit/models/escala_model_test.dart
@@ -3,7 +3,7 @@ import 'package:sggm/models/escalas.dart';
 
 void main() {
   group('Escala.fromJson', () {
-    test('deserializa data_hora_ensaio quando presente', () {
+    test('deserializa campos básicos corretamente', () {
       final json = {
         'id': 1,
         'musico': 10,
@@ -11,76 +11,74 @@ void main() {
         'musico_nome': 'Erickson',
         'evento_nome': 'Culto',
         'confirmado': false,
-        'data_hora_ensaio': '2026-03-10T18:00:00',
+        'observacao': 'Teste',
+        'instrumento_nome': 'Violão',
       };
 
       final escala = Escala.fromJson(json);
 
-      expect(escala.dataHoraEnsaio, isNotNull);
-      expect(escala.dataHoraEnsaio, equals(DateTime.parse('2026-03-10T18:00:00')));
+      expect(escala.id, equals(1));
+      expect(escala.musicoId, equals(10));
+      expect(escala.eventoId, equals(20));
+      expect(escala.musicoNome, equals('Erickson'));
+      expect(escala.eventoNome, equals('Culto'));
+      expect(escala.confirmado, isFalse);
+      expect(escala.observacao, equals('Teste'));
     });
 
-    test('data_hora_ensaio fica null quando ausente no JSON', () {
+    test('confirmado usa false como padrão quando ausente', () {
       final json = {
         'id': 1,
         'musico': 10,
         'evento': 20,
-        'musico_nome': 'Erickson',
-        'evento_nome': 'Culto',
+      };
+
+      final escala = Escala.fromJson(json);
+
+      expect(escala.confirmado, isFalse);
+    });
+
+    test('não contém dataHoraEnsaio', () {
+      final json = {
+        'id': 1,
+        'musico': 10,
+        'evento': 20,
         'confirmado': false,
       };
 
       final escala = Escala.fromJson(json);
 
-      expect(escala.dataHoraEnsaio, isNull);
-    });
-
-    test('data_hora_ensaio fica null quando valor é null no JSON', () {
-      final json = {
-        'id': 1,
-        'musico': 10,
-        'evento': 20,
-        'confirmado': false,
-        'data_hora_ensaio': null,
-      };
-
-      final escala = Escala.fromJson(json);
-
-      expect(escala.dataHoraEnsaio, isNull);
+      // dataHoraEnsaio foi movido para Evento
+      expect(escala.toJson().containsKey('data_hora_ensaio'), isFalse);
     });
   });
 
   group('Escala.toJson', () {
-    test('serializa data_hora_ensaio no formato ISO 8601 quando preenchido', () {
-      final dataEnsaio = DateTime(2026, 3, 10, 18, 0, 0);
+    test('serializa campos obrigatórios corretamente', () {
       final escala = Escala(
         musicoId: 10,
         eventoId: 20,
-        dataHoraEnsaio: dataEnsaio,
+        observacao: 'Obs',
       );
 
       final json = escala.toJson();
 
-      expect(json['data_hora_ensaio'], isNotNull);
-      expect(json['data_hora_ensaio'], equals(dataEnsaio.toIso8601String()));
+      expect(json['musico'], equals(10));
+      expect(json['evento'], equals(20));
+      expect(json['observacao'], equals('Obs'));
+      expect(json.containsKey('data_hora_ensaio'), isFalse);
     });
 
-    test('não inclui data_hora_ensaio no JSON quando null', () {
-      final escala = Escala(
-        musicoId: 10,
-        eventoId: 20,
-      );
-
-      final json = escala.toJson();
-
-      expect(json.containsKey('data_hora_ensaio'), isFalse);
+    test('não inclui id quando null', () {
+      final escala = Escala(musicoId: 1, eventoId: 2);
+      expect(escala.toJson().containsKey('id'), isFalse);
     });
   });
 
   group('Escala - estado inicial', () {
-    test('dataHoraEnsaio é null por padrão', () {
+    test('confirmado é false por padrão', () {
       final escala = Escala(musicoId: 1, eventoId: 2);
-      expect(escala.dataHoraEnsaio, isNull);
+      expect(escala.confirmado, isFalse);
     });
   });
 }

--- a/test/unit/models/evento_model_test.dart
+++ b/test/unit/models/evento_model_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sggm/models/eventos.dart';
+
+void main() {
+  group('Evento.fromJson', () {
+    test('deserializa campos básicos corretamente', () {
+      final json = {
+        'id': 1,
+        'nome': 'Culto de Domingo',
+        'tipo': 'CULTO',
+        'data_evento': '2026-03-15T19:00:00',
+        'local': 'Igreja Central',
+        'descricao': 'Culto principal',
+      };
+
+      final evento = Evento.fromJson(json);
+
+      expect(evento.id, equals(1));
+      expect(evento.nome, equals('Culto de Domingo'));
+      expect(evento.tipo, equals('CULTO'));
+      expect(evento.local, equals('Igreja Central'));
+      expect(evento.dataHoraEnsaio, isNull);
+    });
+
+    test('deserializa dataHoraEnsaio quando presente', () {
+      final json = {
+        'id': 1,
+        'nome': 'Culto',
+        'tipo': 'CULTO',
+        'data_evento': '2026-03-15T19:00:00',
+        'local': 'Igreja',
+        'data_hora_ensaio': '2026-03-13T18:00:00',
+      };
+
+      final evento = Evento.fromJson(json);
+
+      expect(evento.dataHoraEnsaio, isNotNull);
+      expect(evento.dataHoraEnsaio, equals(DateTime.parse('2026-03-13T18:00:00')));
+    });
+
+    test('dataHoraEnsaio fica null quando ausente no JSON', () {
+      final json = {
+        'id': 1,
+        'nome': 'Culto',
+        'tipo': 'CULTO',
+        'data_evento': '2026-03-15T19:00:00',
+        'local': 'Igreja',
+      };
+
+      final evento = Evento.fromJson(json);
+
+      expect(evento.dataHoraEnsaio, isNull);
+    });
+
+    test('dataHoraEnsaio fica null quando valor é null no JSON', () {
+      final json = {
+        'id': 1,
+        'nome': 'Culto',
+        'tipo': 'CULTO',
+        'data_evento': '2026-03-15T19:00:00',
+        'local': 'Igreja',
+        'data_hora_ensaio': null,
+      };
+
+      final evento = Evento.fromJson(json);
+
+      expect(evento.dataHoraEnsaio, isNull);
+    });
+
+    test('tipo usa CULTO como padrão quando ausente', () {
+      final json = {
+        'id': 1,
+        'nome': 'Culto',
+        'data_evento': '2026-03-15T19:00:00',
+        'local': 'Igreja',
+      };
+
+      final evento = Evento.fromJson(json);
+
+      expect(evento.tipo, equals('CULTO'));
+    });
+  });
+
+  group('Evento.toJson', () {
+    test('serializa dataHoraEnsaio no formato ISO 8601 quando preenchido', () {
+      final dataEnsaio = DateTime(2026, 3, 13, 18, 0, 0);
+      final evento = Evento(
+        nome: 'Culto',
+        dataEvento: '2026-03-15T19:00:00',
+        local: 'Igreja',
+        dataHoraEnsaio: dataEnsaio,
+      );
+
+      final json = evento.toJson();
+
+      expect(json['data_hora_ensaio'], isNotNull);
+      expect(json['data_hora_ensaio'], equals(dataEnsaio.toIso8601String()));
+    });
+
+    test('não inclui dataHoraEnsaio no JSON quando null', () {
+      final evento = Evento(
+        nome: 'Culto',
+        dataEvento: '2026-03-15T19:00:00',
+        local: 'Igreja',
+      );
+
+      final json = evento.toJson();
+
+      expect(json.containsKey('data_hora_ensaio'), isFalse);
+    });
+
+    test('não inclui id quando null', () {
+      final evento = Evento(
+        nome: 'Culto',
+        dataEvento: '2026-03-15T19:00:00',
+        local: 'Igreja',
+      );
+
+      expect(evento.toJson().containsKey('id'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## O que foi feito

Move o campo `dataHoraEnsaio` do modelo `Escala` para o modelo `Evento`, alinhando o mobile com a mesma refatoração já realizada no backend.

## Motivação

O ensaio é uma preparação para o **evento**, não para a participação individual de cada músico. Com o campo em `Escala`, o líder precisava preencher o mesmo dado N vezes (uma por músico). Movendo para `Evento`, o horário é definido uma única vez.

## Mudanças

- `lib/models/escalas.dart` — campo `dataHoraEnsaio` removido do modelo, construtor, `fromJson` e `toJson`
- `lib/models/eventos.dart` — campo `dataHoraEnsaio` adicionado ao modelo, construtor, `fromJson` e `toJson`
- `lib/controllers/escalas_controller.dart` — referência a `dataHoraEnsaio` removida do `confirmarPresenca`
- `lib/views/escalas_page.dart` — DateTimePicker de ensaio e exibição no card removidos
- `lib/views/eventos_page.dart` — DateTimePicker de ensaio adicionado ao dialog de criação e exibição no card da lista
- `test/unit/models/escala_model_test.dart` — testes de `dataHoraEnsaio` removidos, substituídos por testes dos campos remanescentes
- `test/unit/models/evento_model_test.dart` — arquivo novo com testes completos de `dataHoraEnsaio` no `Evento`

## Testes
- [x] Todos os testes passando
