### PR TITLE
Corrige tratamento de erro ao criar evento

### DIFF
--- a/lib/views/eventos_page.dart
+++ b/lib/views/eventos_page.dart
@@ -172,7 +172,7 @@ class _EventosPageState extends State<EventosPage> {
                               '${dataHoraEnsaio!.minute.toString().padLeft(2, '0')}'
                           : 'Toque para selecionar (opcional)',
                       style: TextStyle(
-                        color: dataHoraEnsaio != null ? Colors.black87 : Colors.grey[500],
+                        color: dataHoraEnsaio != null ? Colors.white : Colors.grey[500],
                       ),
                     ),
                   ),
@@ -213,23 +213,29 @@ class _EventosPageState extends State<EventosPage> {
                   dataHoraEnsaio: dataHoraEnsaio,
                 );
 
-                try {
-                  await Provider.of<EventoProvider>(context, listen: false).adicionarEvento(novoEvento);
-                  if (ctx.mounted) {
-                    Navigator.of(ctx).pop();
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(
-                        content: Text('Evento criado com sucesso!'),
-                        backgroundColor: Colors.green,
-                      ),
-                    );
-                  }
-                } catch (e) {
-                  if (ctx.mounted) {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(content: Text('Erro ao criar evento')),
-                    );
-                  }
+                // ✅ CORREÇÃO: captura o bool retornado
+                final provider = Provider.of<EventoProvider>(context, listen: false);
+                final sucesso = await provider.adicionarEvento(novoEvento);
+
+                if (!ctx.mounted) return;
+
+                if (sucesso) {
+                  Navigator.of(ctx).pop();
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('Evento criado com sucesso!'),
+                      backgroundColor: Colors.green,
+                    ),
+                  );
+                } else {
+                  // ✅ Mostra a mensagem de erro real do backend
+                  final erro = provider.errorMessage ?? 'Erro ao criar evento';
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: Text(erro),
+                      backgroundColor: Colors.red,
+                    ),
+                  );
                 }
               },
               child: const Text('Salvar'),


### PR DESCRIPTION
## Problema
Ao tentar criar um evento com data de ensaio posterior ao evento,
o backend retornava erro 400, mas o app exibia "Evento criado com sucesso!"
pois o retorno `bool` de `adicionarEvento()` era ignorado.

## Solução
- Captura o retorno `bool` de `adicionarEvento()`
- Exibe `provider.errorMessage` (mensagem real do backend) em caso de erro
- SnackBar de sucesso só é exibido quando `sucesso == true`
- Remove `try/catch` desnecessário que mascarava os erros
