### PR TITLE
Implementa página de comentários de performance

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,16 +1,32 @@
-{
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Flutter",
-            "type": "dart",
-            "request": "launch",
-            "program": "lib/main.dart"
-        }
+// {
+//     // Use IntelliSense to learn about possible attributes.
+//     // Hover to view descriptions of existing attributes.
+//     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+//     "version": "0.2.0",
+//     "configurations": [
+
+//         {
+//             "name": "Flutter",
+//             "type": "dart",
+//             "request": "launch",
+//             "program": "lib/main.dart"
+//         }
         
 
-    ]
+//     ]
+// }
+
+// .vscode/launch.json
+{
+  "configurations": [
+    {
+      "name": "Dev Local",
+      "request": "launch",
+      "type": "dart",
+      "args": [
+        "--dart-define=BASE_URL=http://192.168.100.22:8000",
+        "--dart-define=TIMEOUT_SECONDS=30"
+      ]
+    }
+  ]
 }

--- a/lib/controllers/comentarios_controller.dart
+++ b/lib/controllers/comentarios_controller.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:sggm/models/comentario.dart';
+import 'package:sggm/services/comentario_service.dart';
+import 'package:sggm/util/app_logger.dart';
+
+class ComentariosProvider extends ChangeNotifier {
+  List<ComentarioPerformance> _comentarios = [];
+  bool _isLoading = false;
+  String? _erro;
+  // ← expõe a última mensagem de erro do criar para a UI mostrar no snackbar
+  String? erroUltimaAcao;
+
+  List<ComentarioPerformance> get comentarios => _comentarios;
+  bool get isLoading => _isLoading;
+  String? get erro => _erro;
+
+  void _setLoading(bool v) {
+    _isLoading = v;
+    notifyListeners();
+  }
+
+  Future<void> listarPorEvento(int eventoId) async {
+    _setLoading(true);
+    _erro = null;
+    try {
+      _comentarios = await ComentarioService.listarPorEvento(eventoId);
+    } catch (e) {
+      _erro = e.toString();
+      AppLogger.error('Erro ao carregar comentários', e);
+    } finally {
+      _setLoading(false);
+    }
+  }
+
+  Future<void> listarPorMusica(int eventoId, int musicaId) async {
+    _setLoading(true);
+    _erro = null;
+    try {
+      // ← passa eventoId também para filtrar corretamente
+      _comentarios = await ComentarioService.listarPorMusica(eventoId, musicaId);
+    } catch (e) {
+      _erro = e.toString();
+      AppLogger.error('Erro ao carregar comentários por música', e);
+    } finally {
+      _setLoading(false);
+    }
+  }
+
+  Future<bool> criar({
+    required int eventoId,
+    int? musicaId,
+    required String texto,
+  }) async {
+    erroUltimaAcao = null;
+    try {
+      final novo = await ComentarioService.criar(
+        eventoId: eventoId,
+        musicaId: musicaId,
+        texto: texto,
+      );
+      _comentarios.insert(0, novo);
+      notifyListeners();
+      return true;
+    } catch (e) {
+      // ← armazena a mensagem real do backend (ex: "Comentários só podem ser publicados...")
+      erroUltimaAcao = e.toString().replaceFirst('Exception: ', '');
+      AppLogger.error('Erro ao criar comentário', e);
+      return false;
+    }
+  }
+
+  Future<bool> editar(int id, String novoTexto) async {
+    try {
+      final atualizado = await ComentarioService.editar(id, novoTexto);
+      final idx = _comentarios.indexWhere((c) => c.id == id);
+      if (idx != -1) {
+        _comentarios[idx] = atualizado;
+        notifyListeners();
+      }
+      return true;
+    } catch (e) {
+      AppLogger.error('Erro ao editar comentário', e);
+      return false;
+    }
+  }
+
+  Future<bool> deletar(int id) async {
+    try {
+      await ComentarioService.deletar(id);
+      _comentarios.removeWhere((c) => c.id == id);
+      notifyListeners();
+      return true;
+    } catch (e) {
+      AppLogger.error('Erro ao deletar comentário', e);
+      return false;
+    }
+  }
+
+  Future<void> reagir(int id) async {
+    try {
+      final resultado = await ComentarioService.reagir(id);
+      final idx = _comentarios.indexWhere((c) => c.id == id);
+      if (idx != -1) {
+        _comentarios[idx] = _comentarios[idx].copyWith(
+          totalReacoes: resultado['total_reacoes'],
+          euCurto: resultado['adicionada'],
+        );
+        notifyListeners();
+      }
+    } catch (e) {
+      AppLogger.error('Erro ao reagir ao comentário', e);
+    }
+  }
+
+  void limpar() {
+    _comentarios = [];
+    _erro = null;
+    erroUltimaAcao = null;
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 
 import 'package:sggm/controllers/auth_controller.dart';
+import 'package:sggm/controllers/comentarios_controller.dart';
 import 'package:sggm/controllers/escalas_controller.dart';
 import 'package:sggm/controllers/eventos_controller.dart';
 import 'package:sggm/controllers/instrumentos_controller.dart';
@@ -73,6 +74,7 @@ class MyApp extends StatelessWidget {
         ChangeNotifierProvider(create: (_) => MusicosProvider()),
         ChangeNotifierProvider(create: (_) => InstrumentosProvider()),
         ChangeNotifierProvider(create: (_) => MusicasProvider()),
+        ChangeNotifierProvider(create: (_) => ComentariosProvider()),
       ],
       child: Consumer<AuthProvider>(
         builder: (context, authProvider, _) {

--- a/lib/models/comentario.dart
+++ b/lib/models/comentario.dart
@@ -1,0 +1,70 @@
+class ComentarioPerformance {
+  final int id;
+  final int evento;
+  final int? musica;
+  final int autor;
+  final String autorNome;
+  final String texto;
+  final DateTime criadoEm;
+  final DateTime? editadoEm;
+  final int totalReacoes;
+  final bool euCurto;
+  final bool podeEditar;
+
+  ComentarioPerformance({
+    required this.id,
+    required this.evento,
+    this.musica,
+    required this.autor,
+    required this.autorNome,
+    required this.texto,
+    required this.criadoEm,
+    this.editadoEm,
+    required this.totalReacoes,
+    required this.euCurto,
+    required this.podeEditar,
+  });
+
+  factory ComentarioPerformance.fromJson(Map<String, dynamic> json) {
+    return ComentarioPerformance(
+      id: json['id'],
+      evento: json['evento'],
+      musica: json['musica'],
+      autor: json['autor'],
+      autorNome: json['autor_nome'] ?? '',
+      texto: json['texto'],
+      criadoEm: DateTime.parse(json['criado_em']),
+      editadoEm: json['editado_em'] != null ? DateTime.parse(json['editado_em']) : null,
+      totalReacoes: json['total_reacoes'] ?? 0,
+      euCurto: json['eu_curto'] ?? false,
+      podeEditar: json['pode_editar'] ?? false,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'evento': evento,
+        'musica': musica,
+        'texto': texto,
+      };
+
+  ComentarioPerformance copyWith({
+    int? totalReacoes,
+    bool? euCurto,
+    String? texto,
+    bool? podeEditar,
+  }) {
+    return ComentarioPerformance(
+      id: id,
+      evento: evento,
+      musica: musica,
+      autor: autor,
+      autorNome: autorNome,
+      texto: texto ?? this.texto,
+      criadoEm: criadoEm,
+      editadoEm: editadoEm,
+      totalReacoes: totalReacoes ?? this.totalReacoes,
+      euCurto: euCurto ?? this.euCurto,
+      podeEditar: podeEditar ?? this.podeEditar,
+    );
+  }
+}

--- a/lib/services/comentario_service.dart
+++ b/lib/services/comentario_service.dart
@@ -1,0 +1,117 @@
+import 'package:sggm/models/comentario.dart';
+import 'package:sggm/services/api_service.dart';
+
+class ComentarioService {
+  static const String _base = '/api/comentarios/';
+
+  static Future<List<ComentarioPerformance>> listarPorEvento(int eventoId) async {
+    final response = await ApiService.get(
+      _base,
+      queryParameters: {'evento': eventoId},
+    );
+    if (response.statusCode == 200) {
+      final data = response.data;
+      final List items = data is Map ? data['results'] ?? [] : data;
+      return items.map((e) => ComentarioPerformance.fromJson(e)).toList();
+    }
+    throw Exception('Erro ao carregar comentários');
+  }
+
+  // ← recebe eventoId E musicaId para filtrar corretamente
+  static Future<List<ComentarioPerformance>> listarPorMusica(
+    int eventoId,
+    int musicaId,
+  ) async {
+    final response = await ApiService.get(
+      _base,
+      queryParameters: {
+        'evento': eventoId,
+        'musica': musicaId,
+      },
+    );
+    if (response.statusCode == 200) {
+      final data = response.data;
+      final List items = data is Map ? data['results'] ?? [] : data;
+      return items.map((e) => ComentarioPerformance.fromJson(e)).toList();
+    }
+    throw Exception('Erro ao carregar comentários');
+  }
+
+  static Future<ComentarioPerformance> criar({
+    required int eventoId,
+    int? musicaId,
+    required String texto,
+  }) async {
+    final response = await ApiService.post(
+      _base,
+      body: {
+        'evento': eventoId,
+        if (musicaId != null) 'musica': musicaId,
+        'texto': texto,
+      },
+    );
+
+    if (response.statusCode == 201) {
+      return ComentarioPerformance.fromJson(response.data);
+    }
+
+    // ── Extrair mensagem de erro do DRF ──
+    final data = response.data;
+    String mensagem = 'Erro ao criar comentário';
+
+    if (data is Map) {
+      if (data.containsKey('detail')) {
+        mensagem = data['detail'].toString();
+      } else if (data.containsKey('non_field_errors')) {
+        final erros = data['non_field_errors'];
+        if (erros is List && erros.isNotEmpty) {
+          mensagem = erros.first.toString();
+        }
+      } else {
+        for (final valor in data.values) {
+          if (valor is List && valor.isNotEmpty) {
+            mensagem = valor.first.toString();
+            break;
+          } else if (valor is String) {
+            mensagem = valor;
+            break;
+          }
+        }
+      }
+    } else if (data is List && data.isNotEmpty) {
+      mensagem = data.first.toString();
+    }
+
+    throw Exception(mensagem);
+  }
+
+  static Future<ComentarioPerformance> editar(int id, String novoTexto) async {
+    final response = await ApiService.patch(
+      '$_base$id/',
+      body: {'texto': novoTexto},
+    );
+    if (response.statusCode == 200) {
+      return ComentarioPerformance.fromJson(response.data);
+    }
+    throw Exception(response.data['detail'] ?? 'Erro ao editar comentário');
+  }
+
+  static Future<void> deletar(int id) async {
+    final response = await ApiService.delete('$_base$id/');
+    if (response.statusCode != 204) {
+      throw Exception('Erro ao deletar comentário');
+    }
+  }
+
+  static Future<Map<String, dynamic>> reagir(int id) async {
+    final response = await ApiService.post('$_base$id/reagir/');
+    if (response.statusCode == 200 || response.statusCode == 201) {
+      return {
+        'status': response.data['status'],
+        'total_reacoes': response.data['total_reacoes'],
+        'adicionada': response.statusCode == 201,
+      };
+    }
+    throw Exception('Erro ao reagir ao comentário');
+  }
+}

--- a/lib/views/comentarios_page.dart
+++ b/lib/views/comentarios_page.dart
@@ -1,0 +1,562 @@
+// ignore_for_file: use_build_context_synchronously
+
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:provider/provider.dart';
+import 'package:sggm/controllers/auth_controller.dart';
+import 'package:sggm/controllers/comentarios_controller.dart';
+import 'package:sggm/models/comentario.dart';
+import 'package:sggm/models/musicas.dart';
+
+class ComentariosPage extends StatefulWidget {
+  final int eventoId;
+  final String eventoNome;
+  final String eventoDataEvento; // ← NOVO: ISO 8601 ex: "2026-02-25T19:00:00"
+  final Musica? musica;
+
+  const ComentariosPage({
+    super.key,
+    required this.eventoId,
+    required this.eventoNome,
+    required this.eventoDataEvento, // ← NOVO
+    this.musica,
+  });
+
+  @override
+  State<ComentariosPage> createState() => _ComentariosPageState();
+}
+
+class _ComentariosPageState extends State<ComentariosPage> {
+  final _textoController = TextEditingController();
+  final _scrollController = ScrollController();
+  bool _enviando = false;
+  late ComentariosProvider _provider;
+
+  // ── Verifica se o evento já aconteceu ──
+  bool get _eventoJaAconteceu {
+    try {
+      final data = DateTime.parse(widget.eventoDataEvento);
+      return data.isBefore(DateTime.now());
+    } catch (_) {
+      return false; // se não conseguir parsear, bloqueia por segurança
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _provider = Provider.of<ComentariosProvider>(context, listen: false);
+    WidgetsBinding.instance.addPostFrameCallback((_) => _carregar());
+  }
+
+  Future<void> _carregar() async {
+    final provider = Provider.of<ComentariosProvider>(context, listen: false);
+    if (widget.musica != null) {
+      await provider.listarPorMusica(widget.eventoId, widget.musica!.id!);
+    } else {
+      await provider.listarPorEvento(widget.eventoId);
+    }
+  }
+
+  Future<void> _enviarComentario() async {
+    if (!_eventoJaAconteceu) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Comentários só são permitidos após o evento ser realizado.'),
+          backgroundColor: Colors.orange,
+        ),
+      );
+      return;
+    }
+
+    final texto = _textoController.text.trim();
+    if (texto.isEmpty) return;
+
+    setState(() => _enviando = true);
+
+    final provider = Provider.of<ComentariosProvider>(context, listen: false);
+
+    final ok = await provider.criar(
+      eventoId: widget.eventoId,
+      musicaId: widget.musica?.id,
+      texto: texto,
+    );
+
+    setState(() => _enviando = false);
+
+    if (ok) {
+      _textoController.clear();
+      if (_scrollController.hasClients) {
+        _scrollController.animateTo(
+          0,
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.easeOut,
+        );
+      }
+    } else {
+      // ← usa a mensagem real do backend em vez de texto fixo
+      final mensagem = _provider.erroUltimaAcao ?? 'Erro ao enviar comentário';
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(mensagem),
+          backgroundColor: Colors.red,
+        ),
+      );
+    }
+  }
+
+  void _mostrarOpcoes(ComentarioPerformance comentario) {
+    showModalBottomSheet(
+      context: context,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (_) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const SizedBox(height: 8),
+            Container(
+              width: 40,
+              height: 4,
+              decoration: BoxDecoration(
+                color: Colors.grey[300],
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+            const SizedBox(height: 8),
+            ListTile(
+              leading: const Icon(Icons.edit_outlined, color: Colors.teal),
+              title: const Text('Editar comentário'),
+              onTap: () {
+                Navigator.pop(context);
+                _mostrarEdicao(comentario);
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.delete_outline, color: Colors.red),
+              title: const Text('Excluir comentário'),
+              onTap: () {
+                Navigator.pop(context);
+                _confirmarExclusao(comentario);
+              },
+            ),
+            const SizedBox(height: 8),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _mostrarEdicao(ComentarioPerformance comentario) {
+    final controller = TextEditingController(text: comentario.texto);
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Editar comentário'),
+        content: TextField(
+          controller: controller,
+          maxLines: 4,
+          autofocus: true,
+          decoration: const InputDecoration(
+            border: OutlineInputBorder(),
+            hintText: 'Edite seu comentário...',
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('Cancelar'),
+          ),
+          ElevatedButton(
+            onPressed: () async {
+              final novoTexto = controller.text.trim();
+              if (novoTexto.isEmpty) return;
+              Navigator.pop(ctx);
+              final ok = await _provider.editar(comentario.id, novoTexto);
+              if (!ok && mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(
+                    content: Text('Erro ao editar comentário'),
+                    backgroundColor: Colors.red,
+                  ),
+                );
+              }
+            },
+            child: const Text('Salvar'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _confirmarExclusao(ComentarioPerformance comentario) {
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Excluir comentário'),
+        content: const Text('Tem certeza que deseja excluir este comentário?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('Cancelar'),
+          ),
+          ElevatedButton(
+            style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
+            onPressed: () async {
+              Navigator.pop(ctx);
+              final ok = await _provider.deletar(comentario.id);
+              if (!ok && mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(
+                    content: Text('Erro ao excluir comentário'),
+                    backgroundColor: Colors.red,
+                  ),
+                );
+              }
+            },
+            child: const Text('Excluir', style: TextStyle(color: Colors.white)),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _formatarTempo(DateTime dt) {
+    final diff = DateTime.now().difference(dt);
+    if (diff.inMinutes < 1) return 'agora';
+    if (diff.inMinutes < 60) return 'há ${diff.inMinutes}min';
+    if (diff.inHours < 24) return 'há ${diff.inHours}h';
+    if (diff.inDays < 7) return 'há ${diff.inDays}d';
+    return '${dt.day.toString().padLeft(2, '0')}/${dt.month.toString().padLeft(2, '0')}/${dt.year}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final auth = Provider.of<AuthProvider>(context, listen: false);
+    final musicoId = auth.userData?['musico_id'];
+    final bloqueado = !_eventoJaAconteceu;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              widget.musica != null ? 'Comentários — ${widget.musica!.titulo}' : 'Comentários',
+              style: const TextStyle(fontSize: 16),
+            ),
+            Text(
+              widget.eventoNome,
+              style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w300),
+            ),
+          ],
+        ),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            tooltip: 'Atualizar',
+            onPressed: _carregar,
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          // ── Banner de aviso quando evento ainda não aconteceu ──
+          if (bloqueado)
+            Container(
+              width: double.infinity,
+              color: Colors.orange.shade800,
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+              child: const Row(
+                children: [
+                  Icon(Icons.lock_clock, color: Colors.white, size: 18),
+                  SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      'Comentários disponíveis após a realização do evento.',
+                      style: TextStyle(color: Colors.white, fontSize: 13),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+
+          // ── Lista de comentários ──
+          Expanded(
+            child: Consumer<ComentariosProvider>(
+              builder: (context, provider, _) {
+                if (provider.isLoading) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+
+                if (provider.erro != null) {
+                  return Center(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        const Icon(Icons.error_outline, size: 48, color: Colors.red),
+                        const SizedBox(height: 8),
+                        Text(
+                          'Erro ao carregar comentários',
+                          style: TextStyle(color: Colors.grey[600]),
+                        ),
+                        const SizedBox(height: 16),
+                        ElevatedButton.icon(
+                          onPressed: _carregar,
+                          icon: const Icon(Icons.refresh),
+                          label: const Text('Tentar novamente'),
+                        ),
+                      ],
+                    ),
+                  );
+                }
+
+                if (provider.comentarios.isEmpty) {
+                  return Center(
+                    child: SingleChildScrollView(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(Icons.chat_bubble_outline, size: 48, color: Colors.grey[400]),
+                          const SizedBox(height: 8),
+                          Text(
+                            'Nenhum comentário ainda.\nSeja o primeiro a comentar!',
+                            textAlign: TextAlign.center,
+                            style: TextStyle(color: Colors.grey[500], fontSize: 15),
+                          ),
+                        ],
+                      ),
+                    ),
+                  );
+                }
+
+                return RefreshIndicator(
+                  onRefresh: _carregar,
+                  child: ListView.builder(
+                    controller: _scrollController,
+                    padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                    itemCount: provider.comentarios.length,
+                    itemBuilder: (context, index) {
+                      final c = provider.comentarios[index];
+                      final ehMeu = c.autor == musicoId;
+
+                      return _ComentarioCard(
+                        comentario: c,
+                        ehMeu: ehMeu,
+                        tempoFormatado: _formatarTempo(c.criadoEm),
+                        onReagir: () => provider.reagir(c.id),
+                        onOpcoes: c.podeEditar ? () => _mostrarOpcoes(c) : null,
+                      );
+                    },
+                  ),
+                );
+              },
+            ),
+          ),
+
+          // ── Campo de novo comentário ──
+          const Divider(height: 1),
+          Container(
+            padding: EdgeInsets.only(
+              left: 12,
+              right: 8,
+              top: 8,
+              bottom: MediaQuery.of(context).viewInsets.bottom + 8,
+            ),
+            color: Theme.of(context).cardColor,
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _textoController,
+                    enabled: !bloqueado, // ← desabilita campo se evento não aconteceu
+                    maxLines: 4,
+                    minLines: 1,
+                    textCapitalization: TextCapitalization.sentences,
+                    decoration: InputDecoration(
+                      hintText: bloqueado
+                          ? 'Disponível após o evento'
+                          : widget.musica != null
+                              ? 'Comentar sobre ${widget.musica!.titulo}...'
+                              : 'Comentar sobre o evento...',
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(24),
+                        borderSide: BorderSide.none,
+                      ),
+                      filled: true,
+                      contentPadding: const EdgeInsets.symmetric(
+                        horizontal: 16,
+                        vertical: 10,
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                _enviando
+                    ? const Padding(
+                        padding: EdgeInsets.all(12),
+                        child: SizedBox(
+                          width: 24,
+                          height: 24,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        ),
+                      )
+                    : IconButton(
+                        icon: const Icon(Icons.send_rounded),
+                        // ← cinza e desabilitado se evento não aconteceu
+                        color: bloqueado ? Colors.grey : Colors.teal,
+                        iconSize: 28,
+                        onPressed: bloqueado ? null : _enviarComentario,
+                      ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 16)
+        ],
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      _provider.limpar();
+    });
+    _textoController.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+}
+
+// ── Widget do card de comentário ──
+class _ComentarioCard extends StatelessWidget {
+  final ComentarioPerformance comentario;
+  final bool ehMeu;
+  final String tempoFormatado;
+  final VoidCallback onReagir;
+  final VoidCallback? onOpcoes;
+
+  const _ComentarioCard({
+    required this.comentario,
+    required this.ehMeu,
+    required this.tempoFormatado,
+    required this.onReagir,
+    this.onOpcoes,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 1,
+      margin: const EdgeInsets.only(bottom: 8),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // ── Cabeçalho ──
+            Row(
+              children: [
+                CircleAvatar(
+                  radius: 16,
+                  backgroundColor: ehMeu ? Colors.teal : Colors.orangeAccent,
+                  child: Text(
+                    comentario.autorNome.isNotEmpty ? comentario.autorNome[0].toUpperCase() : '?',
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
+                      fontSize: 14,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Text(
+                            comentario.autorNome,
+                            style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 13),
+                          ),
+                          if (ehMeu) ...[
+                            const SizedBox(width: 4),
+                            Container(
+                              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+                              decoration: BoxDecoration(
+                                color: Colors.teal.withOpacity(0.15),
+                                borderRadius: BorderRadius.circular(8),
+                              ),
+                              child: const Text(
+                                'você',
+                                style: TextStyle(fontSize: 10, color: Colors.teal),
+                              ),
+                            ),
+                          ],
+                        ],
+                      ),
+                      Text(
+                        tempoFormatado + (comentario.editadoEm != null ? ' · editado' : ''),
+                        style: TextStyle(fontSize: 11, color: Colors.grey[500]),
+                      ),
+                    ],
+                  ),
+                ),
+                if (onOpcoes != null)
+                  IconButton(
+                    icon: const Icon(Icons.more_vert, size: 18),
+                    color: Colors.grey,
+                    onPressed: onOpcoes,
+                    padding: EdgeInsets.zero,
+                    constraints: const BoxConstraints(),
+                  ),
+              ],
+            ),
+
+            // ── Texto ──
+            const SizedBox(height: 8),
+            Text(
+              comentario.texto,
+              style: const TextStyle(fontSize: 14, height: 1.4),
+            ),
+
+            // ── Rodapé: curtida ──
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                InkWell(
+                  onTap: onReagir,
+                  borderRadius: BorderRadius.circular(20),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+                    child: Row(
+                      children: [
+                        Icon(
+                          comentario.euCurto ? Icons.favorite_rounded : Icons.favorite_border_rounded,
+                          size: 18,
+                          color: comentario.euCurto ? Colors.red : Colors.grey,
+                        ),
+                        const SizedBox(width: 4),
+                        Text(
+                          '${comentario.totalReacoes}',
+                          style: TextStyle(
+                            fontSize: 13,
+                            color: comentario.euCurto ? Colors.red : Colors.grey,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/evento_detalhes_page.dart
+++ b/lib/views/evento_detalhes_page.dart
@@ -2,7 +2,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:sggm/controllers/auth_controller.dart'; // ✅ ADICIONAR
+import 'package:sggm/controllers/auth_controller.dart';
 import 'package:sggm/models/instrumentos.dart';
 import 'package:sggm/util/app_logger.dart';
 import 'package:sggm/views/musica_detalhes_page.dart';
@@ -15,6 +15,8 @@ import 'package:sggm/controllers/musicas_controller.dart';
 import 'package:sggm/controllers/musicos_controller.dart';
 import 'package:sggm/models/escalas.dart';
 import 'package:sggm/models/eventos.dart';
+
+import 'package:sggm/views/comentarios_page.dart';
 
 class EventoDetalhesPage extends StatefulWidget {
   final Evento evento;
@@ -80,6 +82,15 @@ class _EventoDetalhesPageState extends State<EventoDetalhesPage> with SingleTick
       return instrumento.nome;
     } catch (e) {
       return 'Desconhecido';
+    }
+  }
+
+  bool get _eventoJaAconteceu {
+    try {
+      final data = DateTime.parse(widget.evento.dataEvento);
+      return data.isBefore(DateTime.now());
+    } catch (_) {
+      return false;
     }
   }
 
@@ -516,7 +527,31 @@ class _EventoDetalhesPageState extends State<EventoDetalhesPage> with SingleTick
                                       const SizedBox(width: 4),
                                       if (musica.linkCifra != null && musica.linkCifra!.isNotEmpty)
                                         const Icon(Icons.music_note, color: Colors.blue, size: 20),
-                                      const SizedBox(width: 8),
+                                      const SizedBox(width: 4),
+                                      IconButton(
+                                        icon: Icon(
+                                          Icons.chat_bubble_outline,
+                                          size: 20,
+                                          color: _eventoJaAconteceu ? Colors.teal : Colors.grey[600],
+                                        ),
+                                        tooltip: _eventoJaAconteceu ? 'Comentários' : 'Disponível após o evento',
+                                        onPressed: _eventoJaAconteceu
+                                            ? () {
+                                                Navigator.push(
+                                                  context,
+                                                  MaterialPageRoute(
+                                                    builder: (_) => ComentariosPage(
+                                                      eventoId: eventoAtual.id!,
+                                                      eventoNome: eventoAtual.nome,
+                                                      eventoDataEvento: eventoAtual.dataEvento,
+                                                      musica: musica,
+                                                    ),
+                                                  ),
+                                                );
+                                              }
+                                            : null, // ← null desabilita o botão automaticamente no Flutter
+                                      ),
+                                      const SizedBox(width: 4),
                                       const Icon(Icons.arrow_forward_ios, size: 16),
                                     ],
                                   ),

--- a/test/unit/controllers/comentarios_controller_test.dart
+++ b/test/unit/controllers/comentarios_controller_test.dart
@@ -1,0 +1,145 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sggm/controllers/comentarios_controller.dart';
+import 'package:sggm/models/comentario.dart';
+
+// Helper para criar ComentarioPerformance sem depender de JSON
+ComentarioPerformance _criarComentario({
+  int id = 1,
+  int evento = 10,
+  int? musica = 5,
+  int autor = 3,
+  String autorNome = 'João',
+  String texto = 'Comentário teste',
+  int totalReacoes = 0,
+  bool euCurto = false,
+  bool podeEditar = true,
+}) {
+  return ComentarioPerformance.fromJson({
+    'id': id,
+    'evento': evento,
+    'musica': musica,
+    'autor': autor,
+    'autor_nome': autorNome,
+    'texto': texto,
+    'criado_em': '2026-02-24T10:00:00.000Z',
+    'editado_em': null,
+    'total_reacoes': totalReacoes,
+    'eu_curto': euCurto,
+    'pode_editar': podeEditar,
+  });
+}
+
+void main() {
+  late ComentariosProvider provider;
+
+  setUp(() {
+    provider = ComentariosProvider();
+  });
+
+  // =====================================================
+  group('ComentariosProvider - Estado inicial', () {
+    test('lista de comentários começa vazia', () {
+      expect(provider.comentarios, isEmpty);
+    });
+
+    test('não está carregando por padrão', () {
+      expect(provider.isLoading, isFalse);
+    });
+
+    test('erro é null por padrão', () {
+      expect(provider.erro, isNull);
+    });
+  });
+
+  // =====================================================
+  group('ComentariosProvider - limpar()', () {
+    test('limpa lista de comentários', () {
+      // Simula estado com dados
+      provider.comentarios.add(_criarComentario());
+      provider.limpar();
+      expect(provider.comentarios, isEmpty);
+    });
+
+    test('limpa erro ao chamar limpar()', () {
+      provider.limpar();
+      expect(provider.erro, isNull);
+    });
+
+    test('isLoading permanece false após limpar()', () {
+      provider.limpar();
+      expect(provider.isLoading, isFalse);
+    });
+  });
+
+  // =====================================================
+  group('ComentarioPerformance - lógica de reação (copyWith)', () {
+    test('toggle: adicionar reação incrementa totalReacoes e euCurto = true', () {
+      final c = _criarComentario(totalReacoes: 2, euCurto: false);
+      final atualizado = c.copyWith(
+        totalReacoes: c.totalReacoes + 1,
+        euCurto: true,
+      );
+
+      expect(atualizado.totalReacoes, equals(3));
+      expect(atualizado.euCurto, isTrue);
+    });
+
+    test('toggle: remover reação decrementa totalReacoes e euCurto = false', () {
+      final c = _criarComentario(totalReacoes: 3, euCurto: true);
+      final atualizado = c.copyWith(
+        totalReacoes: c.totalReacoes - 1,
+        euCurto: false,
+      );
+
+      expect(atualizado.totalReacoes, equals(2));
+      expect(atualizado.euCurto, isFalse);
+    });
+
+    test('totalReacoes não vai abaixo de 0', () {
+      final c = _criarComentario(totalReacoes: 0, euCurto: true);
+      // Simula comportamento seguro
+      final novoTotal = (c.totalReacoes - 1).clamp(0, 9999);
+      final atualizado = c.copyWith(totalReacoes: novoTotal, euCurto: false);
+
+      expect(atualizado.totalReacoes, equals(0));
+    });
+  });
+
+  // =====================================================
+  group('ComentarioPerformance - permissão de edição', () {
+    test('podeEditar true permite edição', () {
+      final c = _criarComentario(podeEditar: true);
+      expect(c.podeEditar, isTrue);
+    });
+
+    test('podeEditar false bloqueia edição', () {
+      final c = _criarComentario(podeEditar: false);
+      expect(c.podeEditar, isFalse);
+    });
+
+    test('comentário de outro autor não pertence ao usuário atual', () {
+      final c = _criarComentario(autor: 99);
+      const musicoAtualId = 1;
+      expect(c.autor == musicoAtualId, isFalse);
+    });
+
+    test('comentário do próprio autor pertence ao usuário atual', () {
+      final c = _criarComentario(autor: 1);
+      const musicoAtualId = 1;
+      expect(c.autor == musicoAtualId, isTrue);
+    });
+  });
+
+  // =====================================================
+  group('ComentarioPerformance - formatação de tempo', () {
+    test('comentário recente tem criadoEm no passado', () {
+      final c = _criarComentario();
+      expect(c.criadoEm.isBefore(DateTime.now()), isTrue);
+    });
+
+    test('comentário sem editado_em não foi editado', () {
+      final c = _criarComentario();
+      expect(c.editadoEm, isNull);
+    });
+  });
+}

--- a/test/unit/models/comentario_model_test
+++ b/test/unit/models/comentario_model_test
@@ -1,0 +1,156 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sggm/models/comentario.dart';
+
+void main() {
+  // ── Fixture reutilizável ──
+  Map<String, dynamic> jsonCompleto() => {
+        'id': 1,
+        'evento': 10,
+        'musica': 5,
+        'autor': 3,
+        'autor_nome': 'João Silva',
+        'texto': 'Ótima performance!',
+        'criado_em': '2026-02-24T10:00:00.000Z',
+        'editado_em': '2026-02-24T11:00:00.000Z',
+        'total_reacoes': 4,
+        'eu_curto': true,
+        'pode_editar': true,
+      };
+
+  // =====================================================
+  group('ComentarioPerformance.fromJson', () {
+    test('desserializa todos os campos corretamente', () {
+      final c = ComentarioPerformance.fromJson(jsonCompleto());
+
+      expect(c.id, equals(1));
+      expect(c.evento, equals(10));
+      expect(c.musica, equals(5));
+      expect(c.autor, equals(3));
+      expect(c.autorNome, equals('João Silva'));
+      expect(c.texto, equals('Ótima performance!'));
+      expect(c.totalReacoes, equals(4));
+      expect(c.euCurto, isTrue);
+      expect(c.podeEditar, isTrue);
+    });
+
+    test('parseia criado_em como DateTime corretamente', () {
+      final c = ComentarioPerformance.fromJson(jsonCompleto());
+      expect(c.criadoEm, isA<DateTime>());
+      expect(c.criadoEm.year, equals(2026));
+      expect(c.criadoEm.month, equals(2));
+      expect(c.criadoEm.day, equals(24));
+    });
+
+    test('parseia editado_em quando presente', () {
+      final c = ComentarioPerformance.fromJson(jsonCompleto());
+      expect(c.editadoEm, isNotNull);
+      expect(c.editadoEm!.hour, equals(11));
+    });
+
+    test('editado_em é null quando ausente no JSON', () {
+      final json = jsonCompleto()..remove('editado_em');
+      final c = ComentarioPerformance.fromJson(json);
+      expect(c.editadoEm, isNull);
+    });
+
+    test('musica é null quando ausente no JSON', () {
+      final json = jsonCompleto()..['musica'] = null;
+      final c = ComentarioPerformance.fromJson(json);
+      expect(c.musica, isNull);
+    });
+
+    test('total_reacoes usa 0 como padrão quando ausente', () {
+      final json = jsonCompleto()..remove('total_reacoes');
+      final c = ComentarioPerformance.fromJson(json);
+      expect(c.totalReacoes, equals(0));
+    });
+
+    test('eu_curto usa false como padrão quando ausente', () {
+      final json = jsonCompleto()..remove('eu_curto');
+      final c = ComentarioPerformance.fromJson(json);
+      expect(c.euCurto, isFalse);
+    });
+
+    test('pode_editar usa false como padrão quando ausente', () {
+      final json = jsonCompleto()..remove('pode_editar');
+      final c = ComentarioPerformance.fromJson(json);
+      expect(c.podeEditar, isFalse);
+    });
+
+    test('autor_nome usa string vazia como padrão quando ausente', () {
+      final json = jsonCompleto()..remove('autor_nome');
+      final c = ComentarioPerformance.fromJson(json);
+      expect(c.autorNome, equals(''));
+    });
+  });
+
+  // =====================================================
+  group('ComentarioPerformance.toJson', () {
+    test('serializa evento, musica e texto corretamente', () {
+      final c = ComentarioPerformance.fromJson(jsonCompleto());
+      final json = c.toJson();
+
+      expect(json['evento'], equals(10));
+      expect(json['musica'], equals(5));
+      expect(json['texto'], equals('Ótima performance!'));
+    });
+
+    test('não inclui campos readonly no toJson', () {
+      final c = ComentarioPerformance.fromJson(jsonCompleto());
+      final json = c.toJson();
+
+      expect(json.containsKey('id'), isFalse);
+      expect(json.containsKey('autor'), isFalse);
+      expect(json.containsKey('autor_nome'), isFalse);
+      expect(json.containsKey('criado_em'), isFalse);
+      expect(json.containsKey('total_reacoes'), isFalse);
+    });
+
+    test('não inclui musica quando null', () {
+      final json = jsonCompleto()..['musica'] = null;
+      final c = ComentarioPerformance.fromJson(json);
+      final resultado = c.toJson();
+      expect(resultado['musica'], isNull);
+    });
+  });
+
+  // =====================================================
+  group('ComentarioPerformance.copyWith', () {
+    test('atualiza totalReacoes mantendo outros campos', () {
+      final c = ComentarioPerformance.fromJson(jsonCompleto());
+      final novo = c.copyWith(totalReacoes: 10);
+
+      expect(novo.totalReacoes, equals(10));
+      expect(novo.id, equals(c.id));
+      expect(novo.texto, equals(c.texto));
+      expect(novo.autorNome, equals(c.autorNome));
+    });
+
+    test('atualiza euCurto para false (toggle off)', () {
+      final c = ComentarioPerformance.fromJson(jsonCompleto());
+      final novo = c.copyWith(euCurto: false, totalReacoes: 3);
+
+      expect(novo.euCurto, isFalse);
+      expect(novo.totalReacoes, equals(3));
+    });
+
+    test('atualiza texto mantendo outros campos', () {
+      final c = ComentarioPerformance.fromJson(jsonCompleto());
+      final novo = c.copyWith(texto: 'Editado!');
+
+      expect(novo.texto, equals('Editado!'));
+      expect(novo.id, equals(c.id));
+      expect(novo.euCurto, equals(c.euCurto));
+    });
+
+    test('sem argumentos retorna objeto com mesmos valores', () {
+      final c = ComentarioPerformance.fromJson(jsonCompleto());
+      final novo = c.copyWith();
+
+      expect(novo.id, equals(c.id));
+      expect(novo.texto, equals(c.texto));
+      expect(novo.totalReacoes, equals(c.totalReacoes));
+      expect(novo.euCurto, equals(c.euCurto));
+    });
+  });
+}


### PR DESCRIPTION
## 📋 Descrição

Implementa a página de comentários de performance para eventos e músicas, com bloqueio de envio para eventos futuros e tratamento robusto de erros do backend.

## ✅ Alterações

### \`lib/views/comentarios_page.dart\`
- Adiciona parâmetro obrigatório \`eventoDataEvento\` para controle de bloqueio
- Bloqueia campo de texto e botão de envio para eventos futuros
- Exibe banner laranja de aviso quando evento ainda não foi realizado
- Corrige crash no \`dispose()\` usando \`SchedulerBinding.addPostFrameCallback\`
- Corrige overflow de 1px no estado vazio da lista
- Usa referência salva \`_provider\` em vez de \`Provider.of\` no \`dispose\`

### \`lib/services/comentario_service.dart\`
- Corrige \`listarPorMusica\` para filtrar por \`eventoId\` + \`musicaId\`
- Melhora tratamento de erros do DRF: \`detail\` → \`non_field_errors\` → outros campos

### \`lib/controllers/comentarios_controller.dart\`
- Adiciona \`erroUltimaAcao\` para expor mensagem real do backend à UI
- Remove \`notifyListeners()\` do \`limpar()\` para evitar setState em árvore locked

## 🔗 Relacionado
- Branch backend: \`feat/feedback-performance\`