### PR TITLE
feat(cifra): melhorias de UX no player de cifras para uso em cultos

### DIFF
--- a/lib/util/cifra_scroll_controller.dart
+++ b/lib/util/cifra_scroll_controller.dart
@@ -1,7 +1,7 @@
 class CifraScrollConfig {
   static const double velocidadePadrao = 130.0;
   static const double velocidadeMin = 10.0;
-  static const double velocidadeMax = 250.0;
+  static const double velocidadeMax = 650.0;
   static const double velocidadeStep = 10.0;
 
   static const double fontSizePadrao = 16.0;
@@ -17,6 +17,8 @@ class CifraScrollConfig {
     this.fontSize = fontSizePadrao,
   });
 
+  // ── Fonte ──────────────────────────────────────────────────────────────────
+
   CifraScrollConfig aumentarFonte() => CifraScrollConfig(
         velocidade: velocidade,
         fontSize: (fontSize + fontSizeStep).clamp(fontSizeMin, fontSizeMax),
@@ -27,6 +29,8 @@ class CifraScrollConfig {
         fontSize: (fontSize - fontSizeStep).clamp(fontSizeMin, fontSizeMax),
       );
 
+  // ── Velocidade (botões) ────────────────────────────────────────────────────
+
   CifraScrollConfig aumentarVelocidade() => CifraScrollConfig(
         velocidade: (velocidade + velocidadeStep).clamp(velocidadeMin, velocidadeMax),
         fontSize: fontSize,
@@ -34,6 +38,13 @@ class CifraScrollConfig {
 
   CifraScrollConfig diminuirVelocidade() => CifraScrollConfig(
         velocidade: (velocidade - velocidadeStep).clamp(velocidadeMin, velocidadeMax),
+        fontSize: fontSize,
+      );
+
+  // ── Velocidade (slider) ────────────────────────────────────────────────────
+
+  CifraScrollConfig comVelocidade(double v) => CifraScrollConfig(
+        velocidade: v.clamp(velocidadeMin, velocidadeMax),
         fontSize: fontSize,
       );
 }

--- a/lib/views/musica_detalhes_page.dart
+++ b/lib/views/musica_detalhes_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:sggm/models/musicas.dart';
 import 'package:sggm/theme/app_theme.dart';
@@ -45,6 +47,10 @@ class _MusicaDetalhesPageState extends State<MusicaDetalhesPage> with SingleTick
 
   late ModoCifra _modoCifra;
 
+  // ── Pause-on-touch ─────────────────────────────────────────────────────────
+  bool _usuarioInteragindo = false; // ✅ era final, não podia ser alterado
+  Timer? _retomadaTimer;
+
   @override
   void initState() {
     super.initState();
@@ -56,6 +62,7 @@ class _MusicaDetalhesPageState extends State<MusicaDetalhesPage> with SingleTick
 
   @override
   void dispose() {
+    _retomadaTimer?.cancel();
     _youtubeController?.dispose();
     _tabController.dispose();
     _scrollController.dispose();
@@ -73,10 +80,11 @@ class _MusicaDetalhesPageState extends State<MusicaDetalhesPage> with SingleTick
   }
 
   void _initTabController() {
-    final tabCount = [_hasYoutube, _hasCifra].where((v) => v).length;
+    final tabCount = [_hasCifra, _hasYoutube].where((v) => v).length;
     _tabController = TabController(
       length: tabCount > 0 ? tabCount : 1,
       vsync: this,
+      initialIndex: 0, // cifra sempre primeiro
     );
   }
 
@@ -94,8 +102,6 @@ class _MusicaDetalhesPageState extends State<MusicaDetalhesPage> with SingleTick
     );
   }
 
-  /// Inicializa a WebView apenas se não há cifra nativa (eager)
-  /// ou de forma lazy quando o usuário trocar para o modo web.
   void _initWebViewSeNecessario() {
     if (_hasCifraWeb && !_hasCifraNativa) {
       _initializeWebView();
@@ -142,7 +148,7 @@ class _MusicaDetalhesPageState extends State<MusicaDetalhesPage> with SingleTick
   }
 
   // ─────────────────────────────────────────────────────────────────────────
-  // Lógica de transposição
+  // Transposição
   // ─────────────────────────────────────────────────────────────────────────
 
   static const _tons = [
@@ -179,7 +185,7 @@ class _MusicaDetalhesPageState extends State<MusicaDetalhesPage> with SingleTick
   }
 
   // ─────────────────────────────────────────────────────────────────────────
-  // Lógica de auto-scroll
+  // Auto-scroll
   // ─────────────────────────────────────────────────────────────────────────
 
   void _toggleAutoScroll() {
@@ -189,7 +195,7 @@ class _MusicaDetalhesPageState extends State<MusicaDetalhesPage> with SingleTick
 
   Future<void> _iniciarAutoScroll() async {
     while (_autoScrollAtivo && mounted) {
-      if (_scrollController.hasClients) {
+      if (!_usuarioInteragindo && _scrollController.hasClients) {
         final maxExtent = _scrollController.position.maxScrollExtent;
         final atual = _scrollController.offset;
 
@@ -271,8 +277,8 @@ class _MusicaDetalhesPageState extends State<MusicaDetalhesPage> with SingleTick
     return TabBar(
       controller: _tabController,
       tabs: [
-        if (_hasYoutube) const Tab(icon: Icon(Icons.play_circle), text: 'Vídeo'),
         if (_hasCifra) const Tab(icon: Icon(Icons.music_note), text: 'Cifra'),
+        if (_hasYoutube) const Tab(icon: Icon(Icons.play_circle), text: 'Vídeo'),
       ],
     );
   }
@@ -282,8 +288,8 @@ class _MusicaDetalhesPageState extends State<MusicaDetalhesPage> with SingleTick
       controller: _tabController,
       physics: const NeverScrollableScrollPhysics(),
       children: [
-        if (_hasYoutube) _buildYoutubeTab(),
         if (_hasCifra) _buildCifraTab(),
+        if (_hasYoutube) _buildYoutubeTab(),
       ],
     );
   }
@@ -356,11 +362,9 @@ class _MusicaDetalhesPageState extends State<MusicaDetalhesPage> with SingleTick
   // ─────────────────────────────────────────────────────────────────────────
 
   Widget _buildCifraTab() {
-    // Apenas uma opção disponível — abre direto sem seletor
     if (_hasCifraNativa && !_hasCifraWeb) return _buildCifraNativa();
     if (!_hasCifraNativa && _hasCifraWeb) return _buildCifraWebView();
 
-    // Ambas disponíveis — exibe seletor
     return Column(
       children: [
         _buildSeletorModoCifra(),
@@ -370,8 +374,6 @@ class _MusicaDetalhesPageState extends State<MusicaDetalhesPage> with SingleTick
       ],
     );
   }
-
-  // ── Seletor local / web ────────────────────────────────────────────────────
 
   Widget _buildSeletorModoCifra() {
     return Container(
@@ -422,11 +424,7 @@ class _MusicaDetalhesPageState extends State<MusicaDetalhesPage> with SingleTick
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(
-              icon,
-              size: 14,
-              color: selecionado ? Colors.white : Colors.white54,
-            ),
+            Icon(icon, size: 14, color: selecionado ? Colors.white : Colors.white54),
             const SizedBox(width: 5),
             Text(
               label,
@@ -443,7 +441,7 @@ class _MusicaDetalhesPageState extends State<MusicaDetalhesPage> with SingleTick
   }
 
   // ─────────────────────────────────────────────────────────────────────────
-  // Cifra nativa (ChordPro)
+  // Cifra nativa
   // ─────────────────────────────────────────────────────────────────────────
 
   Widget _buildCifraNativa() {
@@ -455,11 +453,59 @@ class _MusicaDetalhesPageState extends State<MusicaDetalhesPage> with SingleTick
 
     return Stack(
       children: [
-        Column(
-          children: [
-            _buildBarraTom(),
-            Expanded(child: _buildConteudoCifra(secoes)),
-          ],
+        Listener(
+          onPointerDown: (_) {
+            if (_autoScrollAtivo) {
+              _retomadaTimer?.cancel();
+              setState(() => _usuarioInteragindo = true);
+            }
+          },
+          onPointerUp: (_) {
+            if (_autoScrollAtivo) {
+              _retomadaTimer = Timer(const Duration(seconds: 2), () {
+                if (mounted) {
+                  setState(() => _usuarioInteragindo = false);
+                }
+              });
+            }
+          },
+          child: CustomScrollView(
+            controller: _scrollController,
+            slivers: [
+              // Barra de tom — some ao rolar, volta ao puxar
+              SliverAppBar(
+                automaticallyImplyLeading: false,
+                backgroundColor: const Color(0xFF1E1E1E),
+                pinned: false,
+                floating: true,
+                snap: true,
+                toolbarHeight: 44,
+                flexibleSpace: FlexibleSpaceBar(
+                  collapseMode: CollapseMode.pin,
+                  background: _buildBarraTom(),
+                ),
+              ),
+
+              // Conteúdo da cifra
+              SliverToBoxAdapter(
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 8, 72, 80),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      ...secoes.map(
+                        (s) => CifraSecaoWidget(
+                          secao: s,
+                          fontSize: _scrollConfig.fontSize,
+                        ),
+                      ),
+                      const SizedBox(height: 80),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
         ),
         _buildControlesFixos(),
       ],
@@ -530,22 +576,6 @@ class _MusicaDetalhesPageState extends State<MusicaDetalhesPage> with SingleTick
     );
   }
 
-  Widget _buildConteudoCifra(List<dynamic> secoes) {
-    return SingleChildScrollView(
-      controller: _scrollController,
-      padding: const EdgeInsets.fromLTRB(16, 16, 72, 80),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          ...secoes.map(
-            (s) => CifraSecaoWidget(secao: s, fontSize: _scrollConfig.fontSize),
-          ),
-          const SizedBox(height: 80),
-        ],
-      ),
-    );
-  }
-
   Widget _buildControlesFixos() {
     return CifraFloatingControls(
       config: _scrollConfig,
@@ -553,8 +583,8 @@ class _MusicaDetalhesPageState extends State<MusicaDetalhesPage> with SingleTick
       onToggleScroll: _toggleAutoScroll,
       onFonteMais: () => setState(() => _scrollConfig = _scrollConfig.aumentarFonte()),
       onFonteMenos: () => setState(() => _scrollConfig = _scrollConfig.diminuirFonte()),
-      onVelocidadeMais: () => setState(() => _scrollConfig = _scrollConfig.aumentarVelocidade()),
-      onVelocidadeMenos: () => setState(() => _scrollConfig = _scrollConfig.diminuirVelocidade()),
+      // ✅ slider — substitui onVelocidadeMais/onVelocidadeMenos
+      onVelocidadeChanged: (v) => setState(() => _scrollConfig = _scrollConfig.comVelocidade(v)),
     );
   }
 

--- a/lib/views/widgets/cifra_floating_controls.dart
+++ b/lib/views/widgets/cifra_floating_controls.dart
@@ -8,8 +8,7 @@ class CifraFloatingControls extends StatefulWidget {
   final VoidCallback onToggleScroll;
   final VoidCallback onFonteMais;
   final VoidCallback onFonteMenos;
-  final VoidCallback onVelocidadeMais;
-  final VoidCallback onVelocidadeMenos;
+  final ValueChanged<double> onVelocidadeChanged;
 
   const CifraFloatingControls({
     super.key,
@@ -18,8 +17,7 @@ class CifraFloatingControls extends StatefulWidget {
     required this.onToggleScroll,
     required this.onFonteMais,
     required this.onFonteMenos,
-    required this.onVelocidadeMais,
-    required this.onVelocidadeMenos,
+    required this.onVelocidadeChanged,
   });
 
   @override
@@ -312,12 +310,33 @@ class _CifraFloatingControlsState extends State<CifraFloatingControls> with Sing
       children: [
         const SizedBox(height: 10),
         _buildLabel(Icons.speed, 'Velocidade'),
-        _buildControlRow(
-          valor: '${widget.config.velocidade.toInt()}',
-          onMenos: widget.onVelocidadeMenos,
-          onMais: widget.onVelocidadeMais,
-          iconMenos: Icons.remove,
-          iconMais: Icons.add,
+        const SizedBox(height: 2),
+        Row(
+          children: [
+            const Icon(Icons.directions_walk, size: 14, color: Colors.white38),
+            Expanded(
+              child: SliderTheme(
+                data: SliderTheme.of(context).copyWith(
+                  activeTrackColor: AppTheme.presbyterianoVerde,
+                  inactiveTrackColor: AppTheme.presbyterianoVerde.withValues(alpha: 0.2),
+                  thumbColor: AppTheme.presbyterianoVerdeClaro,
+                  overlayColor: AppTheme.presbyterianoVerde.withValues(alpha: 0.15),
+                  thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 7),
+                  trackHeight: 3,
+                ),
+                child: Slider(
+                  value: widget.config.velocidade,
+                  min: CifraScrollConfig.velocidadeMin, // 10.0
+                  max: CifraScrollConfig.velocidadeMax, // 250.0
+                  divisions: ((CifraScrollConfig.velocidadeMax - CifraScrollConfig.velocidadeMin) /
+                          CifraScrollConfig.velocidadeStep) // (250-10)/10 = 24 divisões
+                      .round(),
+                  onChanged: widget.onVelocidadeChanged,
+                ),
+              ),
+            ),
+            const Icon(Icons.directions_run, size: 14, color: Colors.white38),
+          ],
         ),
       ],
     );

--- a/lib/views/widgets/cifra_secao_widget.dart
+++ b/lib/views/widgets/cifra_secao_widget.dart
@@ -47,19 +47,154 @@ class CifraSecaoWidget extends StatelessWidget {
   Widget _buildLinha(String linha) {
     final parseada = CifraParser.parsearLinha(linha);
 
-    // Linha puramente de letra — sem acordes
+    // Linha SEM acordes — texto simples, deixa o Flutter quebrar normalmente
     if (parseada.acordes.trim().isEmpty) {
-      return _buildTextoLetra(parseada.letra.isEmpty ? '' : parseada.letra);
+      return Padding(
+        padding: const EdgeInsets.only(bottom: 2),
+        child: Text(
+          parseada.letra.isEmpty ? ' ' : parseada.letra,
+          style: TextStyle(
+            fontSize: fontSize,
+            fontFamily: 'RobotoMono',
+            color: Colors.white,
+            height: 1.4,
+          ),
+          // ✅ SoftWrap padrão do Flutter — quebra entre palavras
+          softWrap: true,
+        ),
+      );
     }
 
-    // Linha com acordes: empilha acordes sobre letra com fonte mono
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        _buildTextoAcordes(parseada.acordes),
-        if (parseada.letra.trim().isNotEmpty) _buildTextoLetra(parseada.letra),
-      ],
+    // Linha COM acordes — usa Wrap por palavras
+    final blocos = _parsearBlocosEmPalavras(linha);
+
+    if (blocos.isEmpty) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _buildTextoAcordes(parseada.acordes),
+          if (parseada.letra.trim().isNotEmpty) _buildTextoLetra(parseada.letra),
+        ],
+      );
+    }
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 2),
+      child: Wrap(
+        crossAxisAlignment: WrapCrossAlignment.end,
+        runSpacing: 4,
+        children: blocos.map(_buildBlocoWidget).toList(),
+      ),
     );
+  }
+
+  Widget _buildBlocoWidget(_BlocoAcorde bloco) {
+    final temAcorde = bloco.acorde.isNotEmpty;
+
+    return IntrinsicWidth(
+      child: Padding(
+        padding: EdgeInsets.only(right: bloco.silaba.endsWith(' ') ? 0 : 0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Linha do acorde (ou espaço transparente para manter altura)
+            Text(
+              temAcorde ? bloco.acorde : ' ',
+              style: TextStyle(
+                fontSize: fontSize,
+                fontFamily: 'RobotoMono',
+                color: temAcorde ? AppTheme.presbyterianoVerdeClaro : Colors.transparent,
+                fontWeight: FontWeight.w700,
+                height: 1.2,
+                letterSpacing: 0.5,
+              ),
+            ),
+            // Linha da sílaba/palavra
+            Text(
+              bloco.silaba.isEmpty ? ' ' : bloco.silaba,
+              style: TextStyle(
+                fontSize: fontSize,
+                fontFamily: 'RobotoMono',
+                color: Colors.white,
+                height: 1.4,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// Divide em blocos no nível da PALAVRA para que o Wrap quebre corretamente
+  List<_BlocoAcorde> _parsearBlocosEmPalavras(String linha) {
+    final blocos = <_BlocoAcorde>[];
+    final acordeRegex = RegExp(r'\[([^\]]*)\]');
+
+    // Substitui [ACORDE] por um marcador e reconstrói com posições
+    final partes = <_ParteLinha>[];
+    int cursor = 0;
+
+    for (final match in acordeRegex.allMatches(linha)) {
+      if (match.start > cursor) {
+        partes.add(_ParteLinha(texto: linha.substring(cursor, match.start), acorde: null));
+      }
+      partes.add(_ParteLinha(texto: '', acorde: match.group(1)!));
+      cursor = match.end;
+    }
+    if (cursor < linha.length) {
+      partes.add(_ParteLinha(texto: linha.substring(cursor), acorde: null));
+    }
+
+    // Monta blocos: acorde fica com a palavra imediatamente seguinte
+    String acordePendente = '';
+    String textoPendente = '';
+
+    for (final parte in partes) {
+      if (parte.acorde != null) {
+        // Flush do texto acumulado antes de novo acorde
+        if (textoPendente.isNotEmpty) {
+          // Quebra por espaço: cada "palavra " vira um bloco
+          final palavras = _dividirEmPalavras(textoPendente);
+          for (final p in palavras) {
+            blocos.add(_BlocoAcorde(acorde: acordePendente, silaba: p));
+            acordePendente = '';
+          }
+          textoPendente = '';
+        }
+        acordePendente = parte.acorde!;
+      } else {
+        textoPendente += parte.texto;
+      }
+    }
+
+    // Flush final
+    if (textoPendente.isNotEmpty || acordePendente.isNotEmpty) {
+      final palavras = _dividirEmPalavras(textoPendente);
+      if (palavras.isEmpty) {
+        blocos.add(_BlocoAcorde(acorde: acordePendente, silaba: ''));
+      } else {
+        for (int i = 0; i < palavras.length; i++) {
+          blocos.add(_BlocoAcorde(
+            acorde: i == 0 ? acordePendente : '',
+            silaba: palavras[i],
+          ));
+        }
+      }
+    }
+
+    return blocos;
+  }
+
+  /// Divide texto em palavras preservando o espaço como parte da palavra
+  /// Ex: "nossas mãos, e " → ["nossas ", "mãos, ", "e "]
+  List<String> _dividirEmPalavras(String texto) {
+    final resultado = <String>[];
+    final regex = RegExp(r'\S+\s*');
+    for (final m in regex.allMatches(texto)) {
+      resultado.add(m.group(0)!);
+    }
+    return resultado;
   }
 
   Widget _buildTextoAcordes(String acordes) {
@@ -71,6 +206,7 @@ class CifraSecaoWidget extends StatelessWidget {
         color: AppTheme.presbyterianoVerdeClaro,
         fontWeight: FontWeight.w700,
         height: 1.3,
+        letterSpacing: 1.0, // ✅ espaço extra entre caracteres = acordes respiram
       ),
     );
   }
@@ -83,8 +219,30 @@ class CifraSecaoWidget extends StatelessWidget {
         fontFamily: 'RobotoMono',
         color: Colors.white,
         height: 1.4,
+        letterSpacing: 1.0, // ✅ mantém alinhamento com a linha de acordes
       ),
     );
+  }
+
+  List<_BlocoAcorde> _parsearBlocos(String linha) {
+    final regex = RegExp(r'\[([^\]]*)\]([^\[]*)');
+    final blocos = <_BlocoAcorde>[];
+
+    // ✅ Captura texto ANTES do primeiro acorde (ex: "Dign" em "Dign[C]o")
+    final primeiroMatch = regex.firstMatch(linha);
+    if (primeiroMatch != null && primeiroMatch.start > 0) {
+      final textoBefore = linha.substring(0, primeiroMatch.start);
+      if (textoBefore.isNotEmpty) {
+        blocos.add(_BlocoAcorde(acorde: '', silaba: textoBefore));
+      }
+    }
+
+    // Adiciona os blocos normais acorde + sílaba
+    for (final m in regex.allMatches(linha)) {
+      blocos.add(_BlocoAcorde(acorde: m.group(1) ?? '', silaba: m.group(2) ?? ''));
+    }
+
+    return blocos;
   }
 
   String _labelSecao(TipoSecao tipo) => switch (tipo) {
@@ -94,4 +252,16 @@ class CifraSecaoWidget extends StatelessWidget {
         TipoSecao.ponte => 'PONTE',
         TipoSecao.outro => 'OUTRO',
       };
+}
+
+class _BlocoAcorde {
+  final String acorde;
+  final String silaba;
+  const _BlocoAcorde({required this.acorde, required this.silaba});
+}
+
+class _ParteLinha {
+  final String texto;
+  final String? acorde;
+  const _ParteLinha({required this.texto, required this.acorde});
 }

--- a/lib/views/widgets/cifra_secao_widget.dart
+++ b/lib/views/widgets/cifra_secao_widget.dart
@@ -224,27 +224,6 @@ class CifraSecaoWidget extends StatelessWidget {
     );
   }
 
-  List<_BlocoAcorde> _parsearBlocos(String linha) {
-    final regex = RegExp(r'\[([^\]]*)\]([^\[]*)');
-    final blocos = <_BlocoAcorde>[];
-
-    // ✅ Captura texto ANTES do primeiro acorde (ex: "Dign" em "Dign[C]o")
-    final primeiroMatch = regex.firstMatch(linha);
-    if (primeiroMatch != null && primeiroMatch.start > 0) {
-      final textoBefore = linha.substring(0, primeiroMatch.start);
-      if (textoBefore.isNotEmpty) {
-        blocos.add(_BlocoAcorde(acorde: '', silaba: textoBefore));
-      }
-    }
-
-    // Adiciona os blocos normais acorde + sílaba
-    for (final m in regex.allMatches(linha)) {
-      blocos.add(_BlocoAcorde(acorde: m.group(1) ?? '', silaba: m.group(2) ?? ''));
-    }
-
-    return blocos;
-  }
-
   String _labelSecao(TipoSecao tipo) => switch (tipo) {
         TipoSecao.intro => 'INTRO',
         TipoSecao.verso => 'VERSO',

--- a/test/views/cifra_floating_controls_test.dart
+++ b/test/views/cifra_floating_controls_test.dart
@@ -15,8 +15,7 @@ void main() {
               onToggleScroll: () {},
               onFonteMais: () {},
               onFonteMenos: () {},
-              onVelocidadeMais: () {},
-              onVelocidadeMenos: () {},
+              onVelocidadeChanged: (_) {}, // ✅
             ),
           ]),
         ),
@@ -36,8 +35,7 @@ void main() {
               onToggleScroll: () {},
               onFonteMais: () {},
               onFonteMenos: () {},
-              onVelocidadeMais: () {},
-              onVelocidadeMenos: () {},
+              onVelocidadeChanged: (_) {}, // ✅
             ),
           ]),
         ),
@@ -61,8 +59,7 @@ void main() {
               onToggleScroll: () {},
               onFonteMais: () {},
               onFonteMenos: () {},
-              onVelocidadeMais: () {},
-              onVelocidadeMenos: () {},
+              onVelocidadeChanged: (_) {}, // ✅
             ),
           ]),
         ),


### PR DESCRIPTION
## Motivação
Músicos precisam de agilidade durante o culto: a cifra deve ser
a primeira informação visível e os controles de leitura devem ser
intuitivos e acessíveis com uma mão.

## Mudanças

### `CifraScrollConfig`
- Adiciona método `comVelocidade(double v)` para atualização direta via slider

### `CifraFloatingControls`
- Substitui botões `+/-` de velocidade por `Slider` contínuo (range 10–250, 24 divisões)
- Remove `onVelocidadeMais` / `onVelocidadeMenos` da assinatura pública
- Adiciona `onVelocidadeChanged: ValueChanged<double>`

### `MusicaDetalhesPage`
- **Cifra agora é a Tab 1** (padrão ao abrir a música)
- Barra de tom migrada para `SliverAppBar` com `floating: true` + `snap: true`
  — some ao rolar, reaparece ao puxar de volta
- Implementa pause-on-touch no autoscroll (`_usuarioInteragindo`)
  com retomada automática após 2 segundos
- Remove scroll horizontal (`SingleChildScrollView` lateral eliminado)
- `_retomadaTimer` adicionado ao `dispose()`

### Testes
- `cifra_floating_controls_test.dart` atualizado para nova assinatura

## Tipo de mudança
- [x] Feature
- [x] Refactor
- [x] Bug fix
- [ ] Breaking change

## Testado
- [x] `flutter test` — 134 passed, 0 failed
