### PR TITLE
feat(ui): criar componentes reutilizáveis de UI (#7)

### DIFF
--- a/lib/views/widgets/cards/custom_card.dart
+++ b/lib/views/widgets/cards/custom_card.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+class CustomCard extends StatelessWidget {
+  final Widget child;
+  final VoidCallback? onTap;
+  final EdgeInsets? padding;
+  final Color? color;
+
+  const CustomCard({
+    super.key,
+    required this.child,
+    this.onTap,
+    this.padding,
+    this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final card = Card(
+      color: color,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Padding(
+        padding: padding ?? const EdgeInsets.all(16),
+        child: child,
+      ),
+    );
+
+    if (onTap != null) {
+      return InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(16),
+        child: card,
+      );
+    }
+
+    return card;
+  }
+}

--- a/lib/views/widgets/inputs/custom_text_field.dart
+++ b/lib/views/widgets/inputs/custom_text_field.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+
+class CustomTextField extends StatelessWidget {
+  final TextEditingController controller;
+  final String label;
+  final String? hint;
+  final IconData? prefixIcon;
+  final Widget? suffixIcon;
+  final bool obscureText;
+  final TextInputType? keyboardType;
+  final String? Function(String?)? validator;
+  final int? maxLines;
+  final bool enabled;
+  final FocusNode? focusNode;
+  final Function(String)? onSubmitted;
+
+  const CustomTextField({
+    super.key,
+    required this.controller,
+    required this.label,
+    this.hint,
+    this.prefixIcon,
+    this.suffixIcon,
+    this.obscureText = false,
+    this.keyboardType,
+    this.validator,
+    this.maxLines = 1,
+    this.enabled = true,
+    this.focusNode,
+    this.onSubmitted,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      controller: controller,
+      focusNode: focusNode,
+      obscureText: obscureText,
+      keyboardType: keyboardType,
+      validator: validator,
+      maxLines: maxLines,
+      enabled: enabled,
+      onFieldSubmitted: onSubmitted,
+      style: const TextStyle(
+        color: Colors.white,
+        fontFamily: 'Inknut_Antiqua',
+      ),
+      cursorColor: const Color.fromARGB(255, 6, 124, 41),
+      decoration: InputDecoration(
+        labelText: label,
+        hintText: hint,
+        filled: true,
+        fillColor: const Color(0xFF414141),
+        labelStyle: const TextStyle(
+          color: Colors.white,
+          fontFamily: 'Inknut_Antiqua',
+        ),
+        prefixIcon: prefixIcon != null ? Icon(prefixIcon, color: Theme.of(context).primaryColor) : null,
+        suffixIcon: suffixIcon,
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(25),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(25),
+          borderSide: BorderSide(color: Colors.grey.shade700),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(25),
+          borderSide: const BorderSide(color: Colors.deepPurple, width: 2),
+        ),
+        errorBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(25),
+          borderSide: BorderSide(color: Theme.of(context).colorScheme.error),
+        ),
+        focusedErrorBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(25),
+          borderSide: BorderSide(color: Theme.of(context).colorScheme.error, width: 2),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/widgets/states/empty_state.dart
+++ b/lib/views/widgets/states/empty_state.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import '../buttons/app_button.dart';
+
+class EmptyStateWidget extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String message;
+  final String? actionLabel;
+  final VoidCallback? onAction;
+
+  const EmptyStateWidget({
+    super.key,
+    required this.icon,
+    required this.title,
+    required this.message,
+    this.actionLabel,
+    this.onAction,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(icon, size: 80, color: Colors.grey[600]),
+            const SizedBox(height: 24),
+            Text(
+              title,
+              style: const TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              message,
+              style: TextStyle(fontSize: 14, color: Colors.grey[400]),
+              textAlign: TextAlign.center,
+            ),
+            if (actionLabel != null && onAction != null) ...[
+              const SizedBox(height: 24),
+              AppButton(
+                label: actionLabel!,
+                icon: Icons.add,
+                onPressed: onAction,
+                fullWidth: false,
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/widgets/states/error_state.dart
+++ b/lib/views/widgets/states/error_state.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import '../buttons/app_button.dart';
+
+class ErrorStateWidget extends StatelessWidget {
+  final String message;
+  final VoidCallback? onRetry;
+
+  const ErrorStateWidget({
+    super.key,
+    required this.message,
+    this.onRetry,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.error_outline, size: 80, color: Colors.red[400]),
+            const SizedBox(height: 24),
+            const Text(
+              'Ops! Algo deu errado',
+              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              message,
+              style: TextStyle(fontSize: 14, color: Colors.grey[400]),
+              textAlign: TextAlign.center,
+            ),
+            if (onRetry != null) ...[
+              const SizedBox(height: 24),
+              AppButton(
+                label: 'Tentar Novamente',
+                icon: Icons.refresh,
+                onPressed: onRetry,
+                fullWidth: false,
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## O que foi feito
Criação dos componentes reutilizáveis de UI conforme descrito na issue #7.

## Componentes adicionados
- `CustomTextField` — substitui o `buildTextField` funcional por uma classe com suporte a validator, prefixIcon, suffixIcon e estilo consistente com o projeto
- `CustomCard` — card padronizado com suporte a onTap e padding customizável
- `EmptyStateWidget` — estado vazio com ícone, título, mensagem e ação opcional
- `ErrorStateWidget` — estado de erro com mensagem e botão de retry

## Observações
- `AppButton` já existia e cobre todos os tipos de botão (primary, secondary, danger, ghost), sem necessidade de duplicação
- Os widgets de loading (shimmer, overlay) já existiam antes desta issue
- A substituição nas telas existentes ficará para um próximo commit, mantendo retrocompatibilidade com `buildTextField` e `Card` atuais

## Pendente
- [ ] Substituir em pelo menos 3 telas para cumprir critério de aceitação da issue

Closes #7 (parcialmente)
